### PR TITLE
Correct sourcemap generation on missing row numbers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -287,7 +287,7 @@ from the ``calmjs.parse.sourcemap`` module can be used like so:
         "demo.js"
       ],
       "names": [],
-      "mappings": "AAEA,GAEG;IACC,GACG;IACH,MACM;AACV;AACA;",
+      "mappings": "AAEA;IACI;IACA;AACJ;AACA;",
       "file": "demo.min.js"
     }
     >>> print(stream.getvalue())

--- a/src/calmjs/parse/sourcemap.py
+++ b/src/calmjs/parse/sourcemap.py
@@ -274,9 +274,15 @@ def write(source, stream, names=None, book=None, normalize=True):
             if lineno is None or colno is None:
                 mappings[-1].append((book.sink_column,))
             else:
-                # only track lineno if specified
                 if lineno:
+                    # a new lineno is provided, apply it to the book and
+                    # use the result as the written value.
                     book.source_line = lineno
+                    source_line = book.source_line
+                else:
+                    # no change in offset, do not calculate and assume
+                    # the value to be written is unchanged.
+                    source_line = 0
 
                 # if the provided colno is to be implied, calculate it
                 # based on the previous line length plus the previous
@@ -290,13 +296,13 @@ def write(source, stream, names=None, book=None, normalize=True):
                 if original_name is not None:
                     mappings[-1].append((
                         book.sink_column, filename,
-                        book.source_line, book.source_column,
+                        source_line, book.source_column,
                         name_id
                     ))
                 else:
                     mappings[-1].append((
                         book.sink_column, filename,
-                        book.source_line, book.source_column
+                        source_line, book.source_column
                     ))
 
             # doing this last to update the position for the next line

--- a/src/calmjs/parse/tests/test_sourcemap.py
+++ b/src/calmjs/parse/tests/test_sourcemap.py
@@ -343,7 +343,7 @@ class SourceMapTestCase(unittest.TestCase):
     def test_source_map_inferred(self):
         stream = StringIO()
 
-        # Note the None values, as that signifies inferred elements.
+        # Note the 0 values, as that signifies inferred elements.
         fragments = [
             ('console', 1, 1, None),
             ('.', 1, 8, None),
@@ -359,6 +359,24 @@ class SourceMapTestCase(unittest.TestCase):
         self.assertEqual(names, [])
         self.assertEqual(mapping, [
             [(0, 0, 0, 0)],
+        ])
+
+    def test_source_map_inferred_row_offset(self):
+        stream = StringIO()
+
+        # Note that the first row is 3.
+        fragments = [
+            ('var', 3, 1, None),
+            (' ', 0, 0, None),
+            ('main', 3, 5, None),
+            (';', 0, 0, None),
+        ]
+
+        names, mapping = sourcemap.write(fragments, stream, normalize=False)
+        self.assertEqual(stream.getvalue(), 'var main;')
+        self.assertEqual(names, [])
+        self.assertEqual(mapping, [
+            [(0, 0, 2, 0), (3, 0, 0, 3), (1, 0, 0, 1), (4, 0, 0, 4)],
         ])
 
     def test_source_map_known_standard_newline(self):


### PR DESCRIPTION
Since the bookkeeping was not updated for the row, its value should not be used as it would be a stale one.  This change ensure that is the case.