### PR TITLE
Factory for a "shorthand" wrapper around default shorthand callables.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,20 +152,21 @@ Usage
 -----
 
 As this is a parser library, no executable shell commands are provided.
-There is however a helper function provided at the top level for
+There is however a helper callable object provided at the top level for
 immediate access to the parsing feature.  It may be used like so:
 
 .. code:: python
 
     >>> from calmjs.parse import es5
-    >>> program = es5(u'''
+    >>> program_source = u'''
     ... // simple program
     ... var main = function(greet) {
     ...     var hello = "hello " + greet;
     ...     return hello;
     ... };
     ... console.log(main('world'));
-    ... ''')
+    ... '''
+    >>> program = es5(program_source)
     >>> program  # for a simple repr-like nested view of the ast
     <ES5Program @3:1 ?children=[
       <VarStatement @3:1 ?children=[
@@ -232,11 +233,24 @@ and this is generally not an option that should be enabled on production
 library code that is meant to be reused by other packages (other sources
 referencing the original unobfuscated names will be unable to do so).
 
+Alternatively, direct invocation on a raw string can be done using the
+attributes that were provided under the same name as the base object that
+was imported initially.
+
+.. code:: python
+
+    >>> print(es5.pretty_print(program_source))
+    var main = function(greet) {
+      var hello = "hello " + greet;
+      return hello;
+    };
+    console.log(main('world'));
+
+    >>> print(es5.minify_print(program_source, obfuscate=True))
+    var main=function(b){var a="hello "+b;return a;};console.log(main('world'));
+
 Source map generation
 ~~~~~~~~~~~~~~~~~~~~~
-
-.. TODO should provide a bit higher level that can *_print a string
-   directly; perhaps using that WIP builder factory
 
 For the generation of source maps, a lower level unparser instance can
 be constructed through one of the printer factory functions.  Passing

--- a/src/calmjs/parse/__init__.py
+++ b/src/calmjs/parse/__init__.py
@@ -3,12 +3,7 @@
 Quick access helper functions
 """
 
-from calmjs.parse.parsers.es5 import Parser as ES5Parser
+from calmjs.parse.factory import ParserUnparserFactory
 
 
-def es5(source):
-    """
-    Return an AST from the input ES5 source.
-    """
-
-    return ES5Parser().parse(source)
+es5 = ParserUnparserFactory('es5', 'pretty_print', 'minify_print')

--- a/src/calmjs/parse/factory.py
+++ b/src/calmjs/parse/factory.py
@@ -7,11 +7,7 @@ from functools import partial
 from calmjs.parse import asttypes
 
 
-class _M(object):
-    pass
-
-
-class Factory(object):
+class SRFactory(object):
     """
     A factory that will generate a new subclass that has the specified
     __str__ and __repr__ implementations.  Given the number of potential
@@ -34,8 +30,10 @@ class Factory(object):
                 '__repr__': __repr__,
                 '__str__': __str__,
             }) for cls in (
-                # type(_M) replicates the removed types.ClassType
-                v for v in vars(module).values() if isinstance(v, type(_M))
+                # type(type(self)) creates the class "type", which works
+                # like the removed types.ClassType.
+                v for v in vars(module).values() if isinstance(
+                    v, type(type(self)))
             )
         )}
 
@@ -50,4 +48,4 @@ class Factory(object):
         return self.classes[attr]
 
 
-AstTypesFactory = partial(Factory, asttypes)
+AstTypesFactory = partial(SRFactory, asttypes)

--- a/src/calmjs/parse/tests/test_factory.py
+++ b/src/calmjs/parse/tests/test_factory.py
@@ -2,11 +2,11 @@
 import unittest
 
 from calmjs.parse import asttypes
-from calmjs.parse.factory import Factory
+from calmjs.parse.factory import SRFactory
 from calmjs.parse.factory import AstTypesFactory
 
 
-class FactoryTestCase(unittest.TestCase):
+class SRFactoryTestCase(unittest.TestCase):
 
     def test_basic(self):
         # a quick and dirty classes and a container
@@ -29,7 +29,7 @@ class FactoryTestCase(unittest.TestCase):
         o.A = A
         o.B = B
 
-        factory = Factory(o, dummy_str, dummy_repr)
+        factory = SRFactory(o, dummy_str, dummy_repr)
         a = A()
         wrapped_a = factory.A()
         self.assertNotEqual(str(a), '65')

--- a/src/calmjs/parse/tests/test_factory.py
+++ b/src/calmjs/parse/tests/test_factory.py
@@ -57,3 +57,17 @@ class SRFactoryTestCase(unittest.TestCase):
         self.assertFalse(repr(normal_node).startswith('Node has id'))
         self.assertEqual(str(custom_node), 'This is a Node')
         self.assertTrue(repr(custom_node).startswith('Node has id'))
+
+
+class ParserUnparserFactoryTestCase(unittest.TestCase):
+
+    def test_base(self):
+        # simply just test the basic functions... while the top level
+        # readme covers this, just ensure this covers it
+        from calmjs.parse import es5
+
+        src = u'var a;'
+        self.assertTrue(isinstance(es5(src), asttypes.Node))
+        self.assertEqual(es5.pretty_print(src).strip(), src)
+        self.assertEqual(es5.minify_print(src), src)
+        self.assertEqual(es5.minify_print(src, True, True), src)


### PR DESCRIPTION
So that the base es5 object can also have unparsers at attributes that will process a string directly, rather than through the parser step.