### PR TITLE
Fix issue with minified drop semicolon output

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,25 @@
 Changelog
 =========
 
+1.1.1 - 2018-08-??
+------------------
+
+- Ensure that the accounting of layout rule chunks is done correctly in
+  the case where layout handlers specified a tuple of layout rules for
+  combined handling.  [
+  `#19 <https://github.com/calmjs/calmjs.parse/issues/19>`_
+  ]
+
+  - The issue caused by this error manifest severely in the case where
+    multiple layout rule tokens are produced in a manner that repeats
+    a pattern that also have a layout handler rule for them, which
+    does not typically happen for normal code with the standard printers
+    (as layout chunks are many and they generally do not result in a
+    repeated pattern that gets consumed).  However this is severely
+    manifested in the case of minified output with semicolons dropped,
+    as that basically guarantee that any series of closing blocks that
+    fit the pattern to be simply dropped.
+
 1.1.0 - 2018-08-07
 ------------------
 

--- a/src/calmjs/parse/tests/test_es5_unparser.py
+++ b/src/calmjs/parse/tests/test_es5_unparser.py
@@ -2166,11 +2166,19 @@ MinifyPrintTestCase = build_equality_testcase(
 )
 
 
+def minify_drop_semi_helper(tree):
+    result = minify_print(
+        tree, obfuscate=True, shadow_funcname=True, drop_semi=True)
+    # try to parse the result to ensure that it also is valid
+    new_tree = es5(result)
+    assert result == minify_print(
+        new_tree, obfuscate=True, shadow_funcname=True, drop_semi=True)
+    return result
+
+
 MinifyDropSemiPrintTestCase = build_equality_testcase(
     'MinifyDropSemiPrintTestCase',
-    partial(
-        minify_print, obfuscate=True, shadow_funcname=True, drop_semi=True
-    ), ((
+    minify_drop_semi_helper, ((
         label,
         parse(textwrap.dedent(source).strip()),
         answer,

--- a/src/calmjs/parse/tests/test_es5_unparser.py
+++ b/src/calmjs/parse/tests/test_es5_unparser.py
@@ -2284,5 +2284,16 @@ MinifyDropSemiPrintTestCase = build_equality_testcase(
         })();
         """,
         '(function $(){(function a(){var a=1})()})()',
+    ), (
+        'nested_return_function',
+        """
+        v = function() {
+            return function() {
+                return function() {
+                };
+            };
+        };
+        """,
+        'v=function(){return function(){return function(){}}}',
     )])
 )

--- a/src/calmjs/parse/unparsers/walker.py
+++ b/src/calmjs/parse/unparsers/walker.py
@@ -303,30 +303,31 @@ def walk(dispatcher, node, definition=None):
         # the preliminary stack that will be cleared whenever a
         # normalized layout rule chunk is generated.
         lrcs_stack = []
-        rule_stack = []
 
         # first pass: generate both the normalized/finalized lrcs.
         for lrc in layout_rule_chunks:
-            rule_stack.append(lrc.rule)
+            lrcs_stack.append(lrc)
 
             # check every single chunk from left to right...
-            for idx in range(len(rule_stack)):
-                handler = dispatcher.layout(tuple(rule_stack[idx:]))
+            for idx in range(len(lrcs_stack)):
+                rule = tuple(lrc.rule for lrc in lrcs_stack[idx:])
+                handler = dispatcher.layout(rule)
                 if handler is not NotImplemented:
+                    # not manipulating lrsc_stack from within the same
+                    # for loop that it is being iterated upon
                     break
             else:
-                lrcs_stack.append(lrc)
+                # which continues back to the top of the outer for loop
                 continue
 
             # So a handler is found from inside the rules; extend the
             # chunks from the stack that didn't get normalized, and
-            # generate a new layout rule chunk.  Junk the stack after.
+            # generate a new layout rule chunk.
             lrcs_stack[:] = lrcs_stack[:idx]
             lrcs_stack.append(LayoutChunk(
-                tuple(rule_stack[idx:]), handler,
+                rule, handler,
                 layout_rule_chunks[idx].node,
             ))
-            rule_stack[:] = rule_stack[:idx] + [tuple(rule_stack[idx:])]
 
         # second pass: now the processing can be done.
         for lr_chunk in lrcs_stack:

--- a/src/calmjs/parse/unparsers/walker.py
+++ b/src/calmjs/parse/unparsers/walker.py
@@ -326,7 +326,7 @@ def walk(dispatcher, node, definition=None):
                 tuple(rule_stack[idx:]), handler,
                 layout_rule_chunks[idx].node,
             ))
-            rule_stack[:] = [tuple(rule_stack[idx:])]
+            rule_stack[:] = rule_stack[:idx] + [tuple(rule_stack[idx:])]
 
         # second pass: now the processing can be done.
         for lr_chunk in lrcs_stack:


### PR DESCRIPTION
This was a dumb accounting mistake with merging/combining of layout chunk rules on matched layouts, as previously two different lists were used for the tracking and a single offset generated from one was applied to both, however the accounting list will go out of sync (in length, thus offset) with the actual one that stores the rules to be applied, thus this will result in layouts chunks being dropped thus certain mismatched output will simply occur.

This set of changes provide a corrected accounting method to make use of just the actual complete layout rule chunk accounting stack, and provide an additional test to ensure that the produced output can still be parsed again.