### PR TITLE
Fix line numbering when <CR><LF> is encountered

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+1.1.2 - 2018-??-??
+------------------
+
+- The same line terminator regex introduced in 1.1.0 used for line
+  continuation in strings now applied to the line terminator pattern to
+  the lexer, such that the line numbering is corrected for the Windows
+  specific <CR><LF> sequence.  [
+  `#21 <https://github.com/calmjs/calmjs.parse/issues/21>`_
+  ]
+
 1.1.1 - 2018-08-11
 ------------------
 

--- a/src/calmjs/parse/lexers/es5.py
+++ b/src/calmjs/parse/lexers/es5.py
@@ -476,7 +476,7 @@ class Lexer(object):
     t_BLOCK_COMMENT = r'/\*[^*]*\*+([^/*][^*]*\*+)*/'
 
     # 7.3 Line Terminators
-    t_LINE_TERMINATOR = r'\s'
+    t_LINE_TERMINATOR = r'(\n|\r(?!\n)|\u2028|\u2029|\r\n)'
 
     t_ignore = (
         # space, tab, line tab, form feed, nbsp

--- a/src/calmjs/parse/tests/test_es5_parser.py
+++ b/src/calmjs/parse/tests/test_es5_parser.py
@@ -2213,6 +2213,67 @@ ParsedNodeTypeTestCase = build_equality_testcase(
               node=<GroupingOp @1:4 expr=<Identifier @1:5 value='value'>>>>>
         ]>
         """
+    ), (
+        'crlf_lineno',
+        """
+        var dummy = function() {\r\n    return 0;\r\n};
+        """,
+        r"""
+        <ES5Program @1:1 ?children=[<VarStatement @1:1 ?children=[
+          <VarDecl @1:5 identifier=<Identifier @1:5 value='dummy'>,
+            initializer=<FuncExpr @1:13 elements=[
+              <Return @2:5 expr=<Number @2:12 value='0'>>
+            ], identifier=None, parameters=[]>
+          >
+        ]>]>
+        """
+    ), (
+        'nlcr_lineno',
+        """
+        var dummy = function() {\n\r    return 0;\n\r};
+        """,
+        r"""
+        <ES5Program @1:1 ?children=[<VarStatement @1:1 ?children=[
+          <VarDecl @1:5 identifier=<Identifier @1:5 value='dummy'>,
+            initializer=<FuncExpr @1:13 elements=[
+              <Return @3:5 expr=<Number @3:12 value='0'>>
+            ], identifier=None, parameters=[]>
+          >
+        ]>]>
+        """
+    ), (
+        'crlf_lineno_line_cont',
+        """
+        var dummy = function() {\r\n  var r = '\\\r\n  ';\r\n  return r;\r\n};
+        """,
+        r"""
+        <ES5Program @1:1 ?children=[<VarStatement @1:1 ?children=[
+          <VarDecl @1:5 identifier=<Identifier @1:5 value='dummy'>,
+            initializer=<FuncExpr @1:13 elements=[
+              <VarStatement @2:3 ?children=[
+                <VarDecl @2:7 identifier=<Identifier @2:7 value='r'>,
+                  initializer=<String @2:11 value="'\\\r\n  '">>
+                ]>,
+              <Return @4:3 expr=<Identifier @4:10 value='r'>>
+            ],
+            identifier=None, parameters=[]>
+          >
+        ]>]>
+        """
+    ), (
+        'cr_lineno',
+        """
+        var dummy = function() {\r    return 0;\r};
+        """,
+        r"""
+        <ES5Program @1:1 ?children=[<VarStatement @1:1 ?children=[
+          <VarDecl @1:5 identifier=<Identifier @1:5 value='dummy'>,
+            initializer=<FuncExpr @1:13 elements=[
+              <Return @2:5 expr=<Number @2:12 value='0'>>
+            ], identifier=None, parameters=[]>
+          >
+        ]>]>
+        """
     )])
 )
 


### PR DESCRIPTION
The introduction of the support of the line continuation mark inside a string caused a mismatch with how the line terminators are tracked by the lexer. The result is that line number count becomes inflated when <CR><LF> (`\r\n`) is encountered as both tokens are passed separately.

These changes ensure that there is a test case that checks for the correct lineno/colno for the relevant nodes, such that when these values are ultimately used to generate a source map it won't affect users  of code produced by the platform that is stuck using that token.