### PR TITLE
Ensure statements include proper separator

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,6 +11,12 @@ ignore =
     # - src/calmjs/parse/tests/test_es5_lexer.py
     E501,
 
+    # various files/rules, was not a problem flake in 3.5.0
+    W504,
+    # not even sure what is this one is about, because it's pointing to
+    # locations that made no sense.
+    W605,
+
 include =
     src/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ matrix:
       python: 2.7
       env: TRAVIS_NODE_VERSION=4.9
     - language: python
-      python: 3.3
-      env: TRAVIS_NODE_VERSION=6.14
-    - language: python
       python: 3.4
       env: TRAVIS_NODE_VERSION=8.9
     - language: python

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+1.1.3 - 2018-11-??
+------------------
+
+- Correct issues with certain non-optional spaces being omitted for the
+  minify print cases, which caused malformed outputs.  [
+  `#22 <https://github.com/calmjs/calmjs.parse/issues/22>`_
+  ]
+
 1.1.2 - 2018-08-20
 ------------------
 

--- a/src/calmjs/parse/handlers/core.py
+++ b/src/calmjs/parse/handlers/core.py
@@ -35,7 +35,7 @@ from calmjs.parse.ruletypes import (
 )
 from calmjs.parse.lexers.es5 import PATT_LINE_CONTINUATION
 
-required_space = re.compile(r'^(?:\w\w|\+\+|\-\-)$')
+required_space = re.compile(r'^(?:\w\w|\+\+|\-\-|\w\$|\$\w)$')
 
 # the various assignments symbols; for dealing with pretty spacing
 assignment_tokens = {

--- a/src/calmjs/parse/tests/test_es5_unparser.py
+++ b/src/calmjs/parse/tests/test_es5_unparser.py
@@ -2175,6 +2175,30 @@ MinifyPrintTestCase = build_equality_testcase(
         var $foo = bar;
         """,
         'var $foo=bar;',
+    ), (
+        'return_string',
+        """
+        return "foo";
+        """,
+        'return"foo";'
+    ), (
+        'return_statement_negation',
+        """
+        return !1;
+        """,
+        'return!1;'
+    ), (
+        'return_nonword',
+        """
+        return $foo;
+        """,
+        'return $foo;'
+    ), (
+        'return_underscore',
+        """
+        return _;
+        """,
+        'return _;'
     )])
 )
 

--- a/src/calmjs/parse/tests/test_es5_unparser.py
+++ b/src/calmjs/parse/tests/test_es5_unparser.py
@@ -9,6 +9,7 @@ from calmjs.parse import asttypes
 from calmjs.parse import es5
 from calmjs.parse.ruletypes import Declare
 from calmjs.parse.ruletypes import Space
+from calmjs.parse.ruletypes import RequiredSpace
 from calmjs.parse.ruletypes import Text
 from calmjs.parse.parsers.es5 import parse
 from calmjs.parse.walkers import Walker
@@ -78,6 +79,7 @@ class BaseVisitorTestCase(unittest.TestCase):
     def test_basic_var_space_drop(self):
         unparser = Unparser(layout_handlers={
             Space: layout_handler_space_drop,
+            RequiredSpace: layout_handler_space_drop,
         })
         ast = parse('var x = 0;\nvar y = 0;')
         self.assertEqual(quad(unparser(ast)), [
@@ -1767,6 +1769,11 @@ ES5IdentityTestCase = build_equality_testcase(
           ";
         }
         """,
+    ), (
+        'var_non_word_char_separation',
+        """
+        var $foo = bar;
+        """,
     )]))
 )
 
@@ -2162,6 +2169,12 @@ MinifyPrintTestCase = build_equality_testcase(
           ";
         """,
         'var a="  ";',
+    ), (
+        'var_non_word_char_separation',
+        r"""
+        var $foo = bar;
+        """,
+        'var $foo=bar;',
     )])
 )
 

--- a/src/calmjs/parse/tests/test_es5_unparser.py
+++ b/src/calmjs/parse/tests/test_es5_unparser.py
@@ -2195,7 +2195,7 @@ MinifyPrintTestCase = build_equality_testcase(
     ), (
         'return_string',
         """
-        return "foo";
+        return"foo";
         """,
         'return"foo";'
     ), (
@@ -2247,20 +2247,34 @@ MinifyPrintTestCase = build_equality_testcase(
         """,
         'for($bling$ in $bling$bling$){}',
     ), (
-        'case_nonwords',
+        'iteration_in_str',
+        """
+        for ($bling$ in"bingbling") {
+          console.log($bling$);
+        }
+        """,
+        'for($bling$ in"bingbling"){console.log($bling$);}',
+    ), (
+        'case_various',
         """
         switch (foo) {
           case $dollar:
             break;
+          case !1:
+            break;
+          case"foo":
+            break;
         }
         """,
-        'switch(foo){case $dollar:break;}',
+        'switch(foo){case $dollar:break;case!1:break;case"foo":break;}',
     ), (
-        'throw_nonword',
+        'throw_various',
         """
         throw $exc;
+        throw!1;
+        throw"exception";
         """,
-        'throw $exc;',
+        'throw $exc;throw!1;throw"exception";',
     ), (
         'new_nonword',
         """

--- a/src/calmjs/parse/tests/test_es5_unparser.py
+++ b/src/calmjs/parse/tests/test_es5_unparser.py
@@ -2129,6 +2129,23 @@ MinifyPrintTestCase = build_equality_testcase(
         "set fullName(b){var a=b.split(' ');this.first=a[0];this.last=a[1];}};"
         "})();"
     ), (
+        'object_props_nonword',
+        """
+        (function() {
+          Name.prototype = {
+            get $dollar() {
+              return this.money;
+            },
+
+            set $dollar(value) {
+              this.money = value;
+            }
+          };
+        })();
+        """,
+        "(function(){Name.prototype={get $dollar(){return this.money;},"
+        "set $dollar(a){this.money=a;}};})();"
+    ), (
         'try_catch_shadow',
         """
         (function() {
@@ -2199,6 +2216,57 @@ MinifyPrintTestCase = build_equality_testcase(
         return _;
         """,
         'return _;'
+    ), (
+        'while_loop_break_nonword_label',
+        """
+        while (1) {
+          break $dollar;
+        }
+        """,
+        'while(1){break $dollar;}',
+    ), (
+        'while_continue_nonword_label',
+        """
+        while (1) {
+          continue $dollar;
+        }
+        """,
+        'while(1){continue $dollar;}',
+    ), (
+        'iteration_in_nonword',
+        """
+        for (p in $obj) {
+        }
+        """,
+        'for(p in $obj){}',
+    ), (
+        'iteration_in_nonword_pre',
+        """
+        for ($bling$ in $bling$bling$) {
+        }
+        """,
+        'for($bling$ in $bling$bling$){}',
+    ), (
+        'case_nonwords',
+        """
+        switch (foo) {
+          case $dollar:
+            break;
+        }
+        """,
+        'switch(foo){case $dollar:break;}',
+    ), (
+        'throw_nonword',
+        """
+        throw $exc;
+        """,
+        'throw $exc;',
+    ), (
+        'new_nonword',
+        """
+        new $Money();
+        """,
+        'new $Money();',
     )])
 )
 

--- a/src/calmjs/parse/tests/test_handlers_obfuscation.py
+++ b/src/calmjs/parse/tests/test_handlers_obfuscation.py
@@ -11,6 +11,7 @@ from calmjs.parse.asttypes import Catch
 from calmjs.parse.ruletypes import Attr
 from calmjs.parse.ruletypes import Resolve
 from calmjs.parse.ruletypes import Space
+from calmjs.parse.ruletypes import RequiredSpace
 from calmjs.parse.ruletypes import OpenBlock
 from calmjs.parse.ruletypes import CloseBlock
 from calmjs.parse.ruletypes import EndStatement
@@ -486,6 +487,7 @@ class ObfuscatorTestCase(unittest.TestCase):
         dispatcher = Dispatcher(
             unparser.definitions, token_handler_str_default, {
                 Space: layout_handler_space_minimum,
+                RequiredSpace: layout_handler_space_minimum,
                 OpenBlock: layout_handler_openbrace,
                 CloseBlock: layout_handler_closebrace,
                 EndStatement: layout_handler_semicolon,
@@ -556,6 +558,7 @@ class ObfuscatorTestCase(unittest.TestCase):
         main_dispatcher = Dispatcher(
             unparser.definitions, token_handler_unobfuscate, {
                 Space: layout_handler_space_minimum,
+                RequiredSpace: layout_handler_space_minimum,
                 OpenBlock: layout_handler_openbrace,
                 CloseBlock: layout_handler_closebrace,
                 EndStatement: layout_handler_semicolon,

--- a/src/calmjs/parse/unparsers/es5.py
+++ b/src/calmjs/parse/unparsers/es5.py
@@ -82,7 +82,7 @@ definitions = {
         Attr('left'), OptionalSpace, Attr('op'), Space, Attr('right'),
     ),
     'GetPropAssign': (
-        Text(value='get'), Space, Attr('prop_name'),
+        Text(value='get'), RequiredSpace, Attr('prop_name'),
         PushScope,
         Text(value='('), Text(value=')'), Space,
         OpenBlock,
@@ -93,7 +93,7 @@ definitions = {
         PopScope,
     ),
     'SetPropAssign': (
-        Text(value='set'), Space, Attr('prop_name'), Text(value='('),
+        Text(value='set'), RequiredSpace, Attr('prop_name'), Text(value='('),
         PushScope,
         Attr(Declare('parameter')), Text(value=')'), Space,
         OpenBlock,
@@ -126,7 +126,7 @@ definitions = {
     'ForIn': (
         Text(value='for'), Space, Text(value='('),
         Attr('item'),
-        Space, Text(value='in'), Space,
+        RequiredSpace, Text(value='in'), RequiredSpace,
         Attr('iterable'), Text(value=')'), Space, Attr('statement'),
     ),
     'BinOp': (
@@ -159,11 +159,11 @@ definitions = {
     ),
     'Continue': (
         Text(value='continue'), Optional('identifier', (
-            Space, Attr(attr='identifier'))), EndStatement,
+            RequiredSpace, Attr(attr='identifier'))), EndStatement,
     ),
     'Break': (
-        Text(value='break'), OptionalSpace, Optional('identifier', (
-            Attr(attr='identifier'),)), EndStatement,
+        Text(value='break'), Optional('identifier', (
+            RequiredSpace, Attr(attr='identifier'),)), EndStatement,
     ),
     'Return': (
         Text(value='return'), Optional('expr', (
@@ -193,7 +193,7 @@ definitions = {
         CloseBlock,
     ),
     'Case': (
-        Text(value='case'), Space, Attr('expr'), Text(value=':'),
+        Text(value='case'), RequiredSpace, Attr('expr'), Text(value=':'),
         Indent, Newline,
         JoinAttr('elements', value=(Newline,)),
         Dedent,
@@ -205,7 +205,7 @@ definitions = {
         Dedent,
     ),
     'Throw': (
-        Text(value='throw'), Space, Attr('expr'), EndStatement,
+        Text(value='throw'), RequiredSpace, Attr('expr'), EndStatement,
     ),
     'Debugger': (
         Text(value='debugger'), EndStatement,
@@ -258,7 +258,7 @@ definitions = {
     ),
     'Regex': value,
     'NewExpr': (
-        Text(value='new'), Space, Attr('identifier'), Attr('args'),
+        Text(value='new'), RequiredSpace, Attr('identifier'), Attr('args'),
     ),
     'DotAccessor': (
         Attr('node'), Text(value='.'), Attr('identifier'),

--- a/src/calmjs/parse/unparsers/es5.py
+++ b/src/calmjs/parse/unparsers/es5.py
@@ -62,7 +62,7 @@ definitions = {
         CloseBlock,
     ),
     'VarStatement': (
-        Text(value='var'), Space, children_comma, EndStatement,
+        Text(value='var'), RequiredSpace, children_comma, EndStatement,
     ),
     'VarDecl': (
         Attr(Declare('identifier')), Optional('initializer', (

--- a/src/calmjs/parse/unparsers/es5.py
+++ b/src/calmjs/parse/unparsers/es5.py
@@ -126,7 +126,7 @@ definitions = {
     'ForIn': (
         Text(value='for'), Space, Text(value='('),
         Attr('item'),
-        RequiredSpace, Text(value='in'), RequiredSpace,
+        RequiredSpace, Text(value='in'), Space,
         Attr('iterable'), Text(value=')'), Space, Attr('statement'),
     ),
     'BinOp': (
@@ -193,7 +193,7 @@ definitions = {
         CloseBlock,
     ),
     'Case': (
-        Text(value='case'), RequiredSpace, Attr('expr'), Text(value=':'),
+        Text(value='case'), Space, Attr('expr'), Text(value=':'),
         Indent, Newline,
         JoinAttr('elements', value=(Newline,)),
         Dedent,
@@ -205,7 +205,7 @@ definitions = {
         Dedent,
     ),
     'Throw': (
-        Text(value='throw'), RequiredSpace, Attr('expr'), EndStatement,
+        Text(value='throw'), Space, Attr('expr'), EndStatement,
     ),
     'Debugger': (
         Text(value='debugger'), EndStatement,


### PR DESCRIPTION
Currently, statement such as `VarDecl` may not produce the required whitespace separator between the relevant keyword (i.e. `var`) and the identifier following if the relevant characters meets the standard optional whitespace requirements.  This is demonstrated by a statement such as `var $foo` where it will be contracted to `var$foo` using a rule set that make use of the most minimum layout (i.e. `layout_handler_space_minimum`).

While it is possible to simply have the preceding keyword text token provide the whitespace character, that can break with the sourcemap bookkeeping during the relevant lookup stage so a possible fix is to simply make use of the `RequiredSpace` token.  The changes here done by this issue should resolve the remainder cases where this particular type of issue can occur (i.e. `Text` tokens followed by some `Attr` token).

This issue is first reported by https://github.com/plone/Products.CMFPlone/pull/2616#issuecomment-436890926