### PR TITLE
Fix incorrect hex/unicode escapes (section 7.8.4)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+1.1.4 - 201?-??-??
+------------------
+
+- Correctly fail on incorrect hexadecimal/unicode escape sequences while
+  reporting the specific character location; also report on the starting
+  position of an unterminated string literal.  [
+  `#23 <https://github.com/calmjs/calmjs.parse/issues/23>`_
+  ]
+
 1.1.3 - 2018-11-08
 ------------------
 

--- a/src/calmjs/parse/exceptions.py
+++ b/src/calmjs/parse/exceptions.py
@@ -9,6 +9,10 @@ class ECMASyntaxError(SyntaxError):
     Syntax error for ECMA parsing.
     """
 
+    # TODO formalize construction argument such that various details
+    # such as lexical position and character(s) that caused the error
+    # may be interrogated by the exception handler.
+
 
 class ECMARegexSyntaxError(ECMASyntaxError):
     """

--- a/src/calmjs/parse/lexers/es5.py
+++ b/src/calmjs/parse/lexers/es5.py
@@ -517,7 +517,7 @@ class Lexer(object):
         (?:"                               # opening double quote
             (?: [^"\\\n\r\u2028\u2029]     # no \, line terminators or "
                 | \\(\n|\r(?!\n)|\u2028|\u2029|\r\n)  # or line continuation
-                | \\[a-zA-Z!-\/:-@\[-`{-~] # or escaped characters or
+                | \\[a-tvwyzA-TVWYZ!-\/:-@\[-`{-~] # or escaped chars
                 | \\x[0-9a-fA-F]{2}        # or hex_escape_sequence
                 | \\u[0-9a-fA-F]{4}        # or unicode_escape_sequence
                 | \\(?:[1-7][0-7]{0,2}|[0-7]{2,3})  # or octal_escape_sequence
@@ -529,7 +529,7 @@ class Lexer(object):
         (?:'                               # opening single quote
             (?: [^'\\\n\r\u2028\u2029]     # no \, line terminators or "
                 | \\(\n|\r(?!\n)|\u2028|\u2029|\r\n)  # or line continuation
-                | \\[a-zA-Z!-\/:-@\[-`{-~] # or escaped characters
+                | \\[a-tvwyzA-TVWYZ!-\/:-@\[-`{-~] # or escaped chars
                 | \\x[0-9a-fA-F]{2}        # or hex_escape_sequence
                 | \\u[0-9a-fA-F]{4}        # or unicode_escape_sequence
                 | \\(?:[1-7][0-7]{0,2}|[0-7]{2,3}) # or octal_escape_sequence

--- a/src/calmjs/parse/lexers/es5.py
+++ b/src/calmjs/parse/lexers/es5.py
@@ -515,29 +515,29 @@ class Lexer(object):
     (?:
         # double quoted string
         (?:"                               # opening double quote
-            (?: [^"\\\n\r\u2028\u2029]     # no \, line terminators or "
-                | \\(\n|\r(?!\n)|\u2028|\u2029|\r\n)  # or line continuation
-                | \\[a-tvwyzA-TVWYZ!-\/:-@\[-`{-~] # or escaped chars
-                | \\x[0-9a-fA-F]{2}        # or hex_escape_sequence
-                | \\u[0-9a-fA-F]{4}        # or unicode_escape_sequence
-                | \\(?:[1-7][0-7]{0,2}|[0-7]{2,3})  # or octal_escape_sequence
-                | \\0                      # or <NUL> (15.10.2.11)
+            (?: [^"\\\n\r\u2028\u2029]     # not ", \, line terminators; allow
+                | \\(\n|\r(?!\n)|\u2028|\u2029|\r\n)  # line continuation
+                | \\[a-tvwyzA-TVWYZ!-\/:-@\[-`{-~] # escaped chars
+                | \\x[0-9a-fA-F]{2}        # hex_escape_sequence
+                | \\u[0-9a-fA-F]{4}        # unicode_escape_sequence
+                | \\(?:[1-7][0-7]{0,2}|[0-7]{2,3})  # octal_escape_sequence
+                | \\0                      # <NUL> (15.10.2.11)
             )*?                            # zero or many times
-        ")                                 # closing double quote
+        ")                                 # must have closing double quote
         |
         # single quoted string
         (?:'                               # opening single quote
-            (?: [^'\\\n\r\u2028\u2029]     # no \, line terminators or "
-                | \\(\n|\r(?!\n)|\u2028|\u2029|\r\n)  # or line continuation
-                | \\[a-tvwyzA-TVWYZ!-\/:-@\[-`{-~] # or escaped chars
-                | \\x[0-9a-fA-F]{2}        # or hex_escape_sequence
-                | \\u[0-9a-fA-F]{4}        # or unicode_escape_sequence
-                | \\(?:[1-7][0-7]{0,2}|[0-7]{2,3}) # or octal_escape_sequence
-                | \\0                      # or <NUL> (15.10.2.11)
+            (?: [^'\\\n\r\u2028\u2029]     # not ', \, line terminators; allow
+                | \\(\n|\r(?!\n)|\u2028|\u2029|\r\n)  # line continuation
+                | \\[a-tvwyzA-TVWYZ!-\/:-@\[-`{-~] # escaped chars
+                | \\x[0-9a-fA-F]{2}        # hex_escape_sequence
+                | \\u[0-9a-fA-F]{4}        # unicode_escape_sequence
+                | \\(?:[1-7][0-7]{0,2}|[0-7]{2,3}) # octal_escape_sequence
+                | \\0                      # <NUL> (15.10.2.11)
             )*?                            # zero or many times
-        ')                                 # closing single quote
+        ')                                 # must have closing single quote
     )
-    """  # "
+    """
 
     @ply.lex.TOKEN(string)
     def t_STRING(self, token):
@@ -570,6 +570,7 @@ class Lexer(object):
 
     def t_error(self, token):
         if self.cur_token:
+            # TODO make use of the extended calling signature when done
             raise ECMASyntaxError(
                 'Illegal character %s at %s:%s after %s' % (
                     repr_compat(token.value[0]), token.lineno,

--- a/src/calmjs/parse/tests/lexer.py
+++ b/src/calmjs/parse/tests/lexer.py
@@ -7,7 +7,11 @@ from __future__ import unicode_literals
 
 import textwrap
 
-swapquotes = {39: 34, 34: 39}
+swapquotes = {
+    39: 34, 34: 39,
+    # note the follow are interim error messages
+    96: 39,
+}
 
 # The structure and some test cases are taken
 # from https://bitbucket.org/ned/jslex
@@ -361,7 +365,8 @@ es5_cases = [
     ),
 ]
 
-es5_error_cases = [
+# various string related syntax errors
+es5_error_cases_str = [
     (
         'naked_line_separator_in_string',
         "'test\u2028foo'",
@@ -390,9 +395,16 @@ es5_error_cases = [
     )
 ]
 
+# double quote version
 es5_error_cases_str_dq = [
     (n, arg.translate(swapquotes), msg.translate(swapquotes))
-    for n, arg, msg in es5_error_cases
+    for n, arg, msg in es5_error_cases_str
+]
+
+# single quote version
+es5_error_cases_str_sq = [
+    (n, arg, msg.translate({96: 39}))
+    for n, arg, msg in es5_error_cases_str
 ]
 
 es5_pos_cases = [

--- a/src/calmjs/parse/tests/lexer.py
+++ b/src/calmjs/parse/tests/lexer.py
@@ -7,6 +7,8 @@ from __future__ import unicode_literals
 
 import textwrap
 
+swapquotes = {39: 34, 34: 39}
+
 # The structure and some test cases are taken
 # from https://bitbucket.org/ned/jslex
 es5_cases = [
@@ -376,7 +378,21 @@ es5_error_cases = [
         'naked_cr_in_string',
         "'test\\\n\rfoo'",
         'Illegal character "\'" at 1:1',
+    ), (
+        # note the follow are interim error messages
+        'invalid_hex_sequence',
+        "'fail\\x1'",
+        'Illegal character "\'" at 1:1',
+    ), (
+        'invalid_unicode_sequence',
+        "'fail\\u12'",
+        'Illegal character "\'" at 1:1',
     )
+]
+
+es5_error_cases_str_dq = [
+    (n, arg.translate(swapquotes), msg.translate(swapquotes))
+    for n, arg, msg in es5_error_cases
 ]
 
 es5_pos_cases = [

--- a/src/calmjs/parse/tests/lexer.py
+++ b/src/calmjs/parse/tests/lexer.py
@@ -368,30 +368,48 @@ es5_cases = [
 # various string related syntax errors
 es5_error_cases_str = [
     (
+        'unterminated_string_eof',
+        "var foo = 'test",
+        'Unterminated string literal "\'test" at 1:11',
+    ), (
         'naked_line_separator_in_string',
-        "'test\u2028foo'",
-        'Illegal character "\'" at 1:1',
+        "vaf foo = 'test\u2028foo'",
+        'Unterminated string literal "\'test" at 1:11',
     ), (
         'naked_line_feed_in_string',
-        "'test\u2029foo'",
-        'Illegal character "\'" at 1:1',
+        "var foo = 'test\u2029foo'",
+        'Unterminated string literal "\'test" at 1:11',
     ), (
         'naked_crnl_in_string',
-        "'test\r\nfoo'",
-        'Illegal character "\'" at 1:1',
+        "var foo = 'test\r\nfoo'",
+        'Unterminated string literal "\'test" at 1:11',
     ), (
         'naked_cr_in_string',
-        "'test\\\n\rfoo'",
-        'Illegal character "\'" at 1:1',
+        "var foo = 'test\\\n\rfoo'",
+        # FIXME Note that the \\ is double escaped
+        'Unterminated string literal "\'test\\\\" at 1:11',
     ), (
-        # note the follow are interim error messages
         'invalid_hex_sequence',
-        "'fail\\x1'",
-        'Illegal character "\'" at 1:1',
+        "var foo = 'fail\\x1'",
+        # backticks are converted to single quotes
+        "Invalid hexadecimal escape sequence `\\x1` at 1:16",
     ), (
         'invalid_unicode_sequence',
-        "'fail\\u12'",
-        'Illegal character "\'" at 1:1',
+        "var foo = 'fail\\u12'",
+        "Invalid unicode escape sequence `\\u12` at 1:16",
+    ), (
+        'invalid_hex_sequence_multiline',
+        "var foo = 'foobar\\\r\nfail\\x1'",
+        # backticks are converted to single quotes
+        "Invalid hexadecimal escape sequence `\\x1` at 2:5",
+    ), (
+        'invalid_unicode_sequence_multiline',
+        "var foo = 'foobar\\\nfail\\u12'",
+        "Invalid unicode escape sequence `\\u12` at 2:5",
+    ), (
+        'long_invalid_string_truncated',
+        "var foo = '1234567890abcdetruncated",
+        'Unterminated string literal "\'1234567890abcde..." at 1:11',
     )
 ]
 

--- a/src/calmjs/parse/tests/test_es5_lexer.py
+++ b/src/calmjs/parse/tests/test_es5_lexer.py
@@ -38,7 +38,7 @@ from calmjs.parse.tests.lexer import (
     run_lexer_pos,
     es5_cases,
     es5_pos_cases,
-    es5_error_cases,
+    es5_error_cases_str_sq,
     es5_error_cases_str_dq,
 )
 
@@ -89,7 +89,7 @@ LexerTestCase = build_equality_testcase(
 
 LexerErrorTestCase = build_exception_testcase(
     'LexerErrorTestCase', partial(
-        run_lexer, lexer_cls=Lexer), es5_error_cases, ECMASyntaxError)
+        run_lexer, lexer_cls=Lexer), es5_error_cases_str_sq, ECMASyntaxError)
 
 LexerErrorStrDQTestCase = build_exception_testcase(
     'LexerErrorStrDQTestCase', partial(

--- a/src/calmjs/parse/tests/test_es5_lexer.py
+++ b/src/calmjs/parse/tests/test_es5_lexer.py
@@ -39,6 +39,7 @@ from calmjs.parse.tests.lexer import (
     es5_cases,
     es5_pos_cases,
     es5_error_cases,
+    es5_error_cases_str_dq,
 )
 
 
@@ -89,6 +90,10 @@ LexerTestCase = build_equality_testcase(
 LexerErrorTestCase = build_exception_testcase(
     'LexerErrorTestCase', partial(
         run_lexer, lexer_cls=Lexer), es5_error_cases, ECMASyntaxError)
+
+LexerErrorStrDQTestCase = build_exception_testcase(
+    'LexerErrorStrDQTestCase', partial(
+        run_lexer, lexer_cls=Lexer), es5_error_cases_str_dq, ECMASyntaxError)
 
 LexerPosTestCase = build_equality_testcase(
     'LexerPosTestCase', partial(

--- a/src/calmjs/parse/tests/test_es5_unparser.py
+++ b/src/calmjs/parse/tests/test_es5_unparser.py
@@ -2217,6 +2217,12 @@ MinifyPrintTestCase = build_equality_testcase(
         """,
         'return _;'
     ), (
+        'dollar_instanceof_dollar',
+        """
+        foo$ instanceof $bar;
+        """,
+        'foo$ instanceof $bar;'
+    ), (
         'while_loop_break_nonword_label',
         """
         while (1) {


### PR DESCRIPTION
Figured out how/where incomplete hex and unicode escape sequences end up inside a string lexical token; this is achieved by excluding the relevant header characters from the escape sequence (as the regex is a contracted/simplified form of the full specification). The outstanding issue is the reporting of the first character that violated the grammar which should also be provided before this is merged.