### PR TITLE
Implement preliminary support for comments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,32 @@
 Changelog
 =========
 
+1.2.0 - 20??-??-??
+------------------
+
+- Partial support for parsing of comments.  Currently not all comments
+  will be captured during parsing, due to the desire to simplify access
+  of them through the ``asttypes.Node`` instances with the generic
+  ``comments`` attribute provided by it.  [
+  `#24 <https://github.com/calmjs/calmjs.parse/issues/24>`_
+  ]
+
+  - Enabled by passing ``with_comments=True`` to the parser..
+  - The limitation lines in the fact that if a node maps to multiple
+    tokens (e.g. ``if...else``), the comments that lie immediate before
+    the first will be captured, while the comments that lie immediate to
+    the subsequent ones will be omitted.  The fix would involve
+    providing a full syntax tree node types, and that the parser rules
+    would need to be implemented in a more amenable manner such that the
+    generation of such could be done.
+  - All comments that lie immediately before the node are accessible
+    using the ``comments`` attribute.
+  - These comments nodes will not be yielded via the children() method.
+  - Various features and methods have been updated to account for
+    comments.  Notably, sourcemap generation will be able to deal with
+    source fragments that contain newlines provided that both colno and
+    lineno are provided.
+
 1.1.4 - 201?-??-??
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -553,6 +553,26 @@ Object assignments from a given script file:
 Further details and example usage can be consulted from the various
 docstrings found within the module.
 
+Limitations
+-----------
+
+Comments currently may be incomplete
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Due to the implementation of the lexer/parser along with how the ast
+node types have been implemented, there are restrictions on where the
+comments may be exposed if enabled.  Currently, such limitations exists
+for nodes that are created by production rules that consume multiple
+lexer tokens at once - only comments preceding the first token will be
+captured, with all remaining comments discarded.
+
+For example, this limitation means that any comments before the ``else``
+token will be omitted (as the comment will be provided by the ``if``
+token), as the production rule for an ``If`` node consumes both these
+tokens and the node as implemented only provides a single slot for
+comments.  Likewise, any comments before the ``:`` token in a ternary
+statement will also be discarded as that is the second token consumed
+by the production rule that produces a ``Conditional`` node.
 
 Troubleshooting
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ The following command may be executed to source the latest stable
 version of |calmjs.parse| wheel from PyPI for installation into the
 current Python environment.
 
-.. code:: sh
+.. code:: console
 
     $ pip install calmjs.parse
 
@@ -99,7 +99,7 @@ Development is still ongoing with |calmjs.parse|, for the latest
 features and bug fixes, the development version may be installed through
 git like so:
 
-.. code:: sh
+.. code:: console
 
     $ pip install git+https://github.com/calmjs/calmjs.parse.git#egg=calmjs.parse
 
@@ -133,7 +133,7 @@ users, as they may not have write privileges at that level.
 To execute the optimizer from the shell, the provided helper script may
 be used like so:
 
-.. code:: sh
+.. code:: console
 
     $ python -m calmjs.parse.parsers.optimize
 
@@ -152,7 +152,7 @@ Testing the installation
 To ensure that the |calmjs.parse| installation is functioning correctly,
 the built-in testsuite can be executed by the following:
 
-.. code:: sh
+.. code:: console
 
     $ python -m unittest calmjs.parse.tests.make_suite
 
@@ -174,7 +174,7 @@ As this is a parser library, no executable shell commands are provided.
 There is however a helper callable object provided at the top level for
 immediate access to the parsing feature.  It may be used like so:
 
-.. code:: python
+.. code:: pycon
 
     >>> from calmjs.parse import es5
     >>> program_source = u'''
@@ -206,9 +206,25 @@ immediate access to the parsing feature.  It may be used like so:
 
     >>>
 
-Please note the change in indentation and the lack of comments, as the
-default printer has its own indentation scheme and the parser currently
-skips over comments.
+Please note the change in indentation as the default printer has its own
+indentation scheme.  If comments are needed, the parser can be called
+using ``with_comments=True``:
+
+.. code:: pycon
+
+    >>> program_wc = es5(program_source, with_comments=True)
+    >>> print(program_wc)
+    // simple program
+    var main = function(greet) {
+      var hello = "hello " + greet;
+      return hello;
+    };
+    console.log(main('world'));
+
+    >>>
+
+Also note that there are limitations with the capturing of comments as
+documented in the `Limitations`_ section.
 
 The parser classes are organized under the ``calmjs.parse.parsers``
 module, with each language being under their own module.  A
@@ -230,7 +246,7 @@ parameters, such as what characters to use for indentation: (note that
 the ``__str__`` call implicitly invoked through ``print`` shown
 previously is implemented through this).
 
-.. code:: python
+.. code:: pycon
 
     >>> from calmjs.parse.unparsers.es5 import pretty_print
     >>> print(pretty_print(program, indent_str='    '))
@@ -245,7 +261,7 @@ previously is implemented through this).
 There is also one for printing without any unneeded whitespaces, works
 as a source minifier:
 
-.. code:: python
+.. code:: pycon
 
     >>> from calmjs.parse.unparsers.es5 import minify_print
     >>> print(minify_print(program))
@@ -260,13 +276,13 @@ library code that is meant to be reused by other packages (other sources
 referencing the original unobfuscated names will be unable to do so).
 
 Alternatively, direct invocation on a raw string can be done using the
-attributes that were provided under the same name as the base object that
-was imported initially.  For instance, it can simply pretty print a
-JavaScript source file without comments, or minify the source file
-directly.
+attributes provided under the same name as the above base objects that
+were imported initially.  Relevant keyword arguments would be diverted
+to the appropriate underlying functions, for example:
 
-.. code:: python
+.. code:: pycon
 
+    >>> # pretty print without comments being parsed
     >>> print(es5.pretty_print(program_source))
     var main = function(greet) {
       var hello = "hello " + greet;
@@ -274,6 +290,16 @@ directly.
     };
     console.log(main('world'));
 
+    >>> # pretty print with comments parsed
+    >>> print(es5.pretty_print(program_source, with_comments=True))
+    // simple program
+    var main = function(greet) {
+      var hello = "hello " + greet;
+      return hello;
+    };
+    console.log(main('world'));
+
+    >>> # minify print
     >>> print(es5.minify_print(program_source, obfuscate=True))
     var main=function(b){var a="hello "+b;return a;};console.log(main('world'));
 
@@ -289,7 +315,7 @@ generation of source maps.  There are helper functions from the
 regenerated source code to some stream, along with processing the
 results into a sourcemap file.  An example:
 
-.. code:: python
+.. code:: pycon
 
     >>> import json
     >>> from io import StringIO
@@ -326,7 +352,7 @@ populating the ``"sources"`` list in the resulting source map.  For the
 following example, assign a value to that attribute on the program
 directly.
 
-.. code:: python
+.. code:: pycon
 
     >>> from calmjs.parse.unparsers.es5 import minify_printer
     >>> program.sourcepath = 'demo.js'  # say this was opened there
@@ -358,7 +384,7 @@ The following example shows how to use the function to read from a
 stream and write out the relevant items back out to the write only
 streams:
 
-.. code:: python
+.. code:: pycon
 
     >>> from calmjs.parse import io
     >>> h4_program_src = open('/tmp/html4.js')
@@ -385,7 +411,7 @@ For a simple concatenation of multiple sources into one file, along with
 inline source map (i.e. where the sourceMappingURL is a ``data:`` URL of
 the base64 encoding of the JSON string), the following may be done:
 
-.. code:: python
+.. code:: pycon
 
     >>> files = [open('/tmp/html4.js'), open('/tmp/legacy.js')]
     >>> combined = open('/tmp/combined.js', 'w+')
@@ -434,7 +460,7 @@ handlers can be set up using existing rule provider functions.  For
 instance, a printer for obfuscating identifier names while maintaining
 indentation for the output of an ES5 AST can be constructed like so:
 
-.. code:: python
+.. code:: pycon
 
     >>> from calmjs.parse.unparsers.es5 import Unparser
     >>> from calmjs.parse.rules import indent
@@ -503,7 +529,7 @@ supplies a collection of generic tree walking methods for a tree of AST
 nodes.  The following is an example usage on how one might extract all
 Object assignments from a given script file:
 
-.. code:: python
+.. code:: pycon
 
     >>> from calmjs.parse import es5
     >>> from calmjs.parse.asttypes import Object, VarDecl, FunctionCall
@@ -584,7 +610,7 @@ For platforms or systems that do not have utf8 configured as the default
 encoding, the automatic table generation may fail when constructing a
 parser instance.  An example:
 
-.. code::
+.. code:: pycon
 
     >>> from calmjs.parse.parsers import es5
     >>> parser = es5.Parser()
@@ -600,7 +626,7 @@ parser instance.  An example:
 
 A workaround helper script is provided, it may be executed like so:
 
-.. code:: sh
+.. code:: console
 
     $ python -m calmjs.parse.parsers.optimize
 

--- a/src/calmjs/parse/asttypes.py
+++ b/src/calmjs/parse/asttypes.py
@@ -29,6 +29,7 @@ __author__ = 'Ruslan Spivak <ruslan.spivak@gmail.com>'
 from collections import defaultdict
 from ply.lex import LexToken
 from calmjs.parse.utils import str
+from calmjs.parse.utils import repr_compat
 
 # This should be nodetypes; asttypes means type of AST, and defining a
 # type for the entire tree is not the scope of what's being defined here
@@ -572,13 +573,35 @@ class This(Node):
         pass
 
 
+# Currently, as the comment nodes are typically instantiated directly by
+# the Node.setpos method defined by the class in this module, and that
+# there isn't a easy way to reference the factory produced subclasses
+# that has the appropriate language specific __str__ or __repr__ defined
+# for them, they will be defined as such.
+
+
 class Comments(Node):
-    pass
+
+    def __str__(self):
+        return str('\n').join(str(child) for child in self.children())
+
+    def __repr__(self):
+        return str('<%s ?children=[%s]>' % (
+            type(self).__name__,
+            str(', ').join(repr(child) for child in self.children()),
+        ))
 
 
 class Comment(Node):
     def __init__(self, value):
         self.value = value
+
+    def __str__(self):
+        return self.value
+
+    def __repr__(self):
+        return str('<%s value=%s>' % (
+            type(self).__name__, repr_compat(self.value)))
 
 
 class BlockComment(Comment):

--- a/src/calmjs/parse/factory.py
+++ b/src/calmjs/parse/factory.py
@@ -72,8 +72,8 @@ def RawParserUnparserFactory(parser_name, parse_callable, *unparse_callables):
 
     def build_parse(f):
         @wraps(f)
-        def parse(self, source):
-            return f(source)
+        def parse(self, source, *a, **kw):
+            return f(source, *a, **kw)
         parse.__name__ = parser_name
         parse.__qualname__ = parser_name
         return parse

--- a/src/calmjs/parse/factory.py
+++ b/src/calmjs/parse/factory.py
@@ -61,7 +61,10 @@ def RawParserUnparserFactory(parser_name, parse_callable, *unparse_callables):
     def build_unparse(f):
         @wraps(f)
         def unparse(self, source, *a, **kw):
-            node = parse_callable(source)
+            node = parse_callable(
+                source,
+                with_comments=kw.pop('with_comments', False),
+            )
             return f(node, *a, **kw)
         # a dumb and lazy docstring replacement
         unparse.__doc__ = f.__doc__.replace(

--- a/src/calmjs/parse/handlers/core.py
+++ b/src/calmjs/parse/handlers/core.py
@@ -32,6 +32,8 @@ from calmjs.parse.ruletypes import (
     OptionalNewline,
     Indent,
     Dedent,
+    LineComment as RuleTypeLineComment,
+    BlockComment as RuleTypeBlockComment,
 )
 from calmjs.parse.lexers.es5 import PATT_LINE_CONTINUATION
 
@@ -185,6 +187,11 @@ def deferrable_handler_literal_continuation(dispatcher, node):
     return PATT_LINE_CONTINUATION.sub('', node.value)
 
 
+def deferrable_handler_comment(dispatcher, node):
+    # simply return the value
+    return node.value
+
+
 def default_rules():
     return {'layout_handlers': {
         OpenBlock: layout_handler_openbrace,
@@ -202,6 +209,9 @@ def default_rules():
         # content, simply do nothing.
         (Indent, Newline, Dedent): rule_handler_noop,
         (OptionalSpace, EndStatement): layout_handler_semicolon,
+    }, 'deferrable_handlers': {
+        RuleTypeLineComment: deferrable_handler_comment,
+        RuleTypeBlockComment: deferrable_handler_comment,
     }}
 
 

--- a/src/calmjs/parse/lexers/es5.py
+++ b/src/calmjs/parse/lexers/es5.py
@@ -245,12 +245,9 @@ class Lexer(object):
 
     def token(self):
         token = self._token()
-        if token:
-            if self.hidden_tokens:
-                token.hidden_tokens = self.hidden_tokens
-                self.hidden_tokens = []
-            else:
-                token.hidden_tokens = None
+        if token and self.hidden_tokens:
+            token.hidden_tokens = self.hidden_tokens
+            self.hidden_tokens = []
         return token
 
     def _token(self):

--- a/src/calmjs/parse/parsers/es5.py
+++ b/src/calmjs/parse/parsers/es5.py
@@ -61,7 +61,7 @@ class Parser(object):
 
     def __init__(self, lex_optimize=True, lextab=lextab,
                  yacc_optimize=True, yacctab=yacctab, yacc_debug=False,
-                 yacc_tracking=True, asttypes=asttypes):
+                 yacc_tracking=True, with_comments=False, asttypes=asttypes):
         # A warning: in order for line numbers and column numbers be
         # tracked correctly, ``yacc_tracking`` MUST be turned ON.  As
         # this parser was initially implemented with a number of manual
@@ -80,7 +80,7 @@ class Parser(object):
         self.yacc_debug = yacc_debug
         self.yacc_tracking = yacc_tracking
 
-        self.lexer = Lexer()
+        self.lexer = Lexer(with_comments=with_comments)
         self.lexer.build(optimize=lex_optimize, lextab=lextab)
         self.tokens = self.lexer.tokens
 
@@ -141,6 +141,8 @@ class Parser(object):
         """program : source_elements"""
         p[0] = self.asttypes.ES5Program(p[1])
         p[0].setpos(p)  # require yacc_tracking
+        # TODO should consume all remaining comment tokens from lexer,
+        # so trailing comments be provided
 
     def p_source_elements(self, p):
         """source_elements : empty
@@ -1463,12 +1465,12 @@ class Parser(object):
         p[0] = p[1]
 
 
-def parse(source):
+def parse(source, with_comments=False):
     """
     Return an AST from the input ES5 source.
     """
 
-    parser = Parser()
+    parser = Parser(with_comments=with_comments)
     return parser.parse(source)
 
 

--- a/src/calmjs/parse/rules.py
+++ b/src/calmjs/parse/rules.py
@@ -20,6 +20,9 @@ from calmjs.parse.ruletypes import (
     Dedent,
     Resolve,
     Literal,
+
+    LineComment,
+    BlockComment,
 )
 from calmjs.parse.handlers.core import (
     rule_handler_noop,
@@ -36,6 +39,7 @@ from calmjs.parse.handlers.core import (
     layout_handler_space_minimum,
 
     deferrable_handler_literal_continuation,
+    deferrable_handler_comment,
 
     default_rules,
     minimum_rules,
@@ -152,6 +156,9 @@ def indent(indent_str=None):
             (Space, EndStatement): layout_handler_semicolon,
             (OptionalSpace, EndStatement): layout_handler_semicolon,
             (Indent, Newline, Dedent): rule_handler_noop,
+        }, 'deferrable_handlers': {
+            LineComment: deferrable_handler_comment,
+            BlockComment: deferrable_handler_comment,
         }}
     return indentation_rule
 

--- a/src/calmjs/parse/ruletypes.py
+++ b/src/calmjs/parse/ruletypes.py
@@ -273,6 +273,16 @@ class Attr(Token):
             yield chunk
 
 
+class CommentsAttr(Attr):
+    """
+    Essentially identical to Attr, except default to handling comments
+    such that the rules can be more easily filtered out if required.
+    """
+
+    def __init__(self, attr='comments', value=None, pos=0):
+        super(CommentsAttr, self).__init__(attr=attr, value=value, pos=pos)
+
+
 class Text(Token):
     """
     Simply leverage the dispatcher object for generating the rendering
@@ -489,6 +499,34 @@ class Literal(Deferrable):
             # the handler will return the value
             return handler(dispatcher, node)
         return node.value
+
+
+class Comment(Deferrable):
+    """
+    Provide special handling for comments of either types.
+    """
+
+    # yes this is similar enough to Literal, but for now keep the two
+    # implementation separate until merging can be proven to be harmless
+
+    def __call__(self, dispatcher, node):
+        handler = dispatcher.deferrable(self)
+        if handler is not NotImplemented:
+            # the handler will return the value
+            return handler(dispatcher, node)
+        # do not return a default for now?
+
+
+class LineComment(Comment):
+    """
+    Provide special handling for line comments
+    """
+
+
+class BlockComment(Comment):
+    """
+    Provide special handling for line comments
+    """
 
 
 children_newline = JoinAttr(Iter(), value=(Newline,))

--- a/src/calmjs/parse/tests/lexer.py
+++ b/src/calmjs/parse/tests/lexer.py
@@ -123,29 +123,13 @@ es5_cases = [
         # multiline string (string written across multiple lines
         # of code) https://github.com/rspivak/slimit/issues/24
         'slimit_issue_24_multi_line_code_double',
-        ("var a = 'hello \\\n world'""",
+        ("var a = 'hello \\\n world'",
          ['VAR var', 'ID a', 'EQ =', "STRING 'hello \\\n world'"]),
     ), (
         'slimit_issue_24_multi_line_code_single',
         ('var a = "hello \\\r world"',
          ['VAR var', 'ID a', 'EQ =', 'STRING "hello \\\r world"']),
     ), (
-        # # Comments
-        # ("""
-        # //comment
-        # a = 5;
-        # """, ['LINE_COMMENT //comment', 'ID a', 'EQ =', 'NUMBER 5', 'SEMI ;']
-        #  ),
-        # ('a//comment', ['ID a', 'LINE_COMMENT //comment']),
-        # ('/***/b/=3//line',
-        #  ['BLOCK_COMMENT /***/', 'ID b', 'DIVEQUAL /=',
-        #   'NUMBER 3', 'LINE_COMMENT //line']
-        #  ),
-        # ('/*\n * Copyright LGPL 2011 \n*/\na = 1;',
-        #  ['BLOCK_COMMENT /*\n * Copyright LGPL 2011 \n*/',
-        #   'ID a', 'EQ =', 'NUMBER 1', 'SEMI ;']
-        #  ),
-
         # regex
         'regex_1',
         (r'a=/a*/,1', ['ID a', 'EQ =', 'REGEX /a*/', 'COMMA ,', 'NUMBER 1']),
@@ -347,11 +331,6 @@ es5_cases = [
         ("a = b\n\n\n/hi/s",
          ['ID a', 'EQ =', 'ID b', 'DIV /', 'ID hi', 'DIV /', 'ID s'])
     ), (
-        # okay this is getting ridiculous how bad ECMA is.
-        'section_7_comments',
-        ("a = b\n/** **/\n\n/hi/s",
-         ['ID a', 'EQ =', 'ID b', 'DIV /', 'ID hi', 'DIV /', 'ID s'])
-    ), (
         'slimit_issue_39_and_57',
         (r"f(a, 'hi\01').split('\1').split('\0');",
          ['ID f', 'LPAREN (', 'ID a', 'COMMA ,', r"STRING 'hi\01'", 'RPAREN )',
@@ -362,6 +341,11 @@ es5_cases = [
         'section_7_8_4_string_literal_with_7_3_conformance',
         ("'<LF>\\\n<CR>\\\r<LS>\\\u2028<PS>\\\u2029<CR><LF>\\\r\n'",
          ["STRING '<LF>\\\n<CR>\\\r<LS>\\\u2028<PS>\\\u2029<CR><LF>\\\r\n'"])
+    ), (
+        # okay this is getting ridiculous how bad ECMA is.
+        'section_7_comments',
+        ("a = b\n/** **/\n\n/hi/s",
+         ['ID a', 'EQ =', 'ID b', 'DIV /', 'ID hi', 'DIV /', 'ID s'])
     ),
 ]
 
@@ -412,6 +396,36 @@ es5_error_cases_str = [
         'Unterminated string literal "\'1234567890abcde..." at 1:11',
     )
 ]
+
+es5_comment_cases = [
+    (
+        'line_comment_whole',
+        ('//comment\na = 5;\n',
+         ['LINE_COMMENT //comment', 'ID a', 'EQ =', 'NUMBER 5', 'SEMI ;']),
+    ), (
+        'line_comment_trail',
+        ('a//comment', ['ID a', 'LINE_COMMENT //comment']),
+    ), (
+        'block_comment_single',
+        ('/***/b/=3//line',
+         ['BLOCK_COMMENT /***/', 'ID b', 'DIVEQUAL /=',
+          'NUMBER 3', 'LINE_COMMENT //line']),
+    ), (
+        'block_comment_multiline',
+        ('/*\n * Copyright LGPL 2011 \n*/\na = 1;',
+         ['BLOCK_COMMENT /*\n * Copyright LGPL 2011 \n*/',
+          'ID a', 'EQ =', 'NUMBER 1', 'SEMI ;']),
+    ), (
+        # this will replace the standard test cases
+        'section_7_comments',
+        ("a = b\n/** **/\n\n/hi/s",
+         ['ID a', 'EQ =', 'ID b', 'BLOCK_COMMENT /** **/', 'DIV /', 'ID hi',
+          'DIV /', 'ID s'])
+    )
+]
+
+# replace the section_7_comments test case
+es5_all_cases = es5_cases[:-1] + es5_comment_cases
 
 # double quote version
 es5_error_cases_str_dq = [

--- a/src/calmjs/parse/tests/test_asttypes.py
+++ b/src/calmjs/parse/tests/test_asttypes.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from calmjs.parse.asttypes import Comments
+from calmjs.parse.asttypes import BlockComment
+from calmjs.parse.asttypes import LineComment
+
+
+class CommentNodesTestCase(unittest.TestCase):
+    """
+    Eventually, if a better way to have the lexer some access the
+    specific node types for the syntax being processed, this would not
+    be necessary.
+    """
+
+    def test_block_comment_str_repr(self):
+        node = Comments([
+            BlockComment(u'/* test1 */'),
+            BlockComment(u'/* test2 */'),
+        ])
+        self.assertEqual(
+            "<Comments ?children=[<BlockComment value='/* test1 */'>, "
+            "<BlockComment value='/* test2 */'>]>", repr(node)
+        )
+        self.assertEqual("/* test1 */\n/* test2 */", str(node))
+
+    def test_line_comment_str_repr(self):
+        node = Comments([
+            LineComment(u'// test1'),
+            LineComment(u'// test2'),
+        ])
+        self.assertEqual("// test1\n// test2", str(node))

--- a/src/calmjs/parse/tests/test_es5_lexer.py
+++ b/src/calmjs/parse/tests/test_es5_lexer.py
@@ -98,7 +98,7 @@ class LexerWithCommentsTestCase(unittest.TestCase):
         '''))
         tokens = [token for token in lexer]
         self.assertEqual(2, len(tokens))
-        self.assertIsNone(tokens[0].hidden_tokens)
+        self.assertFalse(hasattr(tokens[0], 'hidden_tokens'))
         token = tokens[1]
         self.assertEqual(1, len(token.hidden_tokens))
         self.assertEqual(token.hidden_tokens[0].value, '// bar')
@@ -112,7 +112,7 @@ class LexerWithCommentsTestCase(unittest.TestCase):
         '''))
         tokens = [token for token in lexer]
         self.assertEqual(2, len(tokens))
-        self.assertIsNone(tokens[0].hidden_tokens)
+        self.assertFalse(hasattr(tokens[0], 'hidden_tokens'))
         token = tokens[1]
         self.assertEqual(1, len(token.hidden_tokens))
         self.assertEqual(token.hidden_tokens[0].value, '/*foo\n*/')

--- a/src/calmjs/parse/tests/test_es5_lexer.py
+++ b/src/calmjs/parse/tests/test_es5_lexer.py
@@ -37,6 +37,7 @@ from calmjs.parse.tests.lexer import (
     run_lexer,
     run_lexer_pos,
     es5_cases,
+    es5_all_cases,
     es5_pos_cases,
     es5_error_cases_str_sq,
     es5_error_cases_str_dq,
@@ -86,6 +87,11 @@ LexerKeywordTestCase = build_equality_testcase(
 LexerTestCase = build_equality_testcase(
     'LexerTestCase', partial(run_lexer, lexer_cls=Lexer), (
         (label, data[0], data[1],) for label, data in es5_cases))
+
+LexerAllTestCase = build_equality_testcase(
+    'LexerAllTestCase', partial(run_lexer, lexer_cls=partial(
+        Lexer, with_comments=True
+    )), ((label, data[0], data[1],) for label, data in es5_all_cases))
 
 LexerErrorTestCase = build_exception_testcase(
     'LexerErrorTestCase', partial(

--- a/src/calmjs/parse/tests/test_es5_lexer.py
+++ b/src/calmjs/parse/tests/test_es5_lexer.py
@@ -26,6 +26,7 @@
 __author__ = 'Ruslan Spivak <ruslan.spivak@gmail.com>'
 
 import unittest
+import textwrap
 from functools import partial
 
 from calmjs.parse.lexers.es5 import Lexer
@@ -71,6 +72,55 @@ class LexerFailureTestCase(unittest.TestCase):
         self.assertEqual(str(e.exception), "Mismatched ')' at 3:3")
 
 
+class LexerWithCommentsTestCase(unittest.TestCase):
+
+    def test_with_line_comments_before(self):
+        lexer = Lexer(with_comments=True)
+        lexer.input(textwrap.dedent('''
+        // foo
+        // bar
+        baz
+        '''))
+        tokens = [token for token in lexer]
+        self.assertEqual(1, len(tokens))
+        token = tokens[0]
+        self.assertEqual(2, len(token.hidden_tokens))
+        self.assertEqual(token.hidden_tokens[0].value, '// foo')
+        self.assertEqual(token.hidden_tokens[0].type, 'LINE_COMMENT')
+        self.assertEqual(token.hidden_tokens[1].value, '// bar')
+        self.assertEqual(token.hidden_tokens[1].type, 'LINE_COMMENT')
+
+    def test_with_line_comment_trail(self):
+        lexer = Lexer(with_comments=True)
+        lexer.input(textwrap.dedent('''
+        baz // bar
+        foo
+        '''))
+        tokens = [token for token in lexer]
+        self.assertEqual(2, len(tokens))
+        self.assertIsNone(tokens[0].hidden_tokens)
+        token = tokens[1]
+        self.assertEqual(1, len(token.hidden_tokens))
+        self.assertEqual(token.hidden_tokens[0].value, '// bar')
+        self.assertEqual(token.hidden_tokens[0].type, 'LINE_COMMENT')
+
+    def test_block_comment(self):
+        lexer = Lexer(with_comments=True)
+        lexer.input(textwrap.dedent('''
+        baz /*foo
+        *// // bar
+        '''))
+        tokens = [token for token in lexer]
+        self.assertEqual(2, len(tokens))
+        self.assertIsNone(tokens[0].hidden_tokens)
+        token = tokens[1]
+        self.assertEqual(1, len(token.hidden_tokens))
+        self.assertEqual(token.hidden_tokens[0].value, '/*foo\n*/')
+        self.assertEqual(token.hidden_tokens[0].type, 'BLOCK_COMMENT')
+        # the remaining comments remain on lexer
+        self.assertEqual(lexer.hidden_tokens[0].value, '// bar')
+
+
 LexerKeywordTestCase = build_equality_testcase(
     'LexerKeywordTestCase', partial(run_lexer, lexer_cls=Lexer), (
         (label, data[0], data[1],) for label, data in [(
@@ -90,7 +140,7 @@ LexerTestCase = build_equality_testcase(
 
 LexerAllTestCase = build_equality_testcase(
     'LexerAllTestCase', partial(run_lexer, lexer_cls=partial(
-        Lexer, with_comments=True
+        Lexer, yield_comments=True
     )), ((label, data[0], data[1],) for label, data in es5_all_cases))
 
 LexerErrorTestCase = build_exception_testcase(

--- a/src/calmjs/parse/unparsers/es5.py
+++ b/src/calmjs/parse/unparsers/es5.py
@@ -24,6 +24,8 @@ from calmjs.parse.ruletypes import (
 )
 from calmjs.parse.ruletypes import (
     Attr,
+    CommentsAttr,
+    Iter,
     Text,
     Optional,
     JoinAttr,
@@ -34,6 +36,8 @@ from calmjs.parse.ruletypes import (
 from calmjs.parse.ruletypes import (
     Literal,
     Declare,
+    LineComment,
+    BlockComment,
     Resolve,
     ResolveFuncName,
 )
@@ -45,6 +49,7 @@ from calmjs.parse.unparsers.base import BaseUnparser
 from calmjs.parse import rules
 
 value = (
+    CommentsAttr(),
     Attr('value'),
 )
 
@@ -55,6 +60,7 @@ definitions = {
         OptionalNewline,
     ),
     'Block': (
+        CommentsAttr(),
         OpenBlock,
         Indent, Newline,
         children_newline,
@@ -62,26 +68,35 @@ definitions = {
         CloseBlock,
     ),
     'VarStatement': (
+        CommentsAttr(),
         Text(value='var'), RequiredSpace, children_comma, EndStatement,
     ),
     'VarDecl': (
+        CommentsAttr(),
         Attr(Declare('identifier')), Optional('initializer', (
             Space, Operator(value='='), Space, Attr('initializer'),),),
     ),
     'VarDeclNoIn': (
+        CommentsAttr(),
         Text(value='var '), Attr(Declare('identifier')),
         Optional('initializer', (
             Space, Operator(value='='), Space, Attr('initializer'),),),
     ),
     'GroupingOp': (
+        CommentsAttr(),
         Text(value='('), Attr('expr'), Text(value=')'),
     ),
-    'Identifier': (Attr(Resolve()),),
+    'Identifier': (
+        CommentsAttr(),
+        Attr(Resolve()),
+    ),
     'PropIdentifier': value,
     'Assign': (
+        CommentsAttr(),
         Attr('left'), OptionalSpace, Attr('op'), Space, Attr('right'),
     ),
     'GetPropAssign': (
+        CommentsAttr(),
         Text(value='get'), RequiredSpace, Attr('prop_name'),
         PushScope,
         Text(value='('), Text(value=')'), Space,
@@ -93,6 +108,7 @@ definitions = {
         PopScope,
     ),
     'SetPropAssign': (
+        CommentsAttr(),
         Text(value='set'), RequiredSpace, Attr('prop_name'), Text(value='('),
         PushScope,
         Attr(Declare('parameter')), Text(value=')'), Space,
@@ -105,10 +121,15 @@ definitions = {
     ),
     'Number': value,
     'Comma': (
+        CommentsAttr(),
         Attr('left'), Text(value=','), Space, Attr('right'),
     ),
-    'EmptyStatement': (EndStatement,),
+    'EmptyStatement': (
+        CommentsAttr(),
+        EndStatement,
+    ),
     'If': (
+        CommentsAttr(),
         Text(value='if'), Space,
         Text(value='('), Attr('predicate'), Text(value=')'), Space,
         Attr('consequent'),
@@ -117,6 +138,7 @@ definitions = {
     ),
     'Boolean': value,
     'For': (
+        CommentsAttr(),
         Text(value='for'), Space, Text(value='('),
         Attr('init'),
         OptionalSpace, Attr('cond'),
@@ -124,52 +146,65 @@ definitions = {
         Text(value=')'), Space, Attr('statement'),
     ),
     'ForIn': (
+        CommentsAttr(),
         Text(value='for'), Space, Text(value='('),
         Attr('item'),
         RequiredSpace, Text(value='in'), Space,
         Attr('iterable'), Text(value=')'), Space, Attr('statement'),
     ),
     'BinOp': (
+        CommentsAttr(),
         Attr('left'), Space, Operator(attr='op'), Space, Attr('right'),
     ),
     'UnaryExpr': (
+        CommentsAttr(),
         Operator(attr='op'), OptionalSpace, Attr('value'),
     ),
     'PostfixExpr': (
+        CommentsAttr(),
         Operator(attr='value'), Attr('op'),
     ),
     'ExprStatement': (
+        CommentsAttr(),
         Attr('expr'), EndStatement,
     ),
     'DoWhile': (
+        CommentsAttr(),
         Text(value='do'), Space, Attr('statement'), Space,
         Text(value='while'), Space, Text(value='('),
         Attr('predicate'), Text(value=')'), EndStatement,
     ),
     'While': (
+        CommentsAttr(),
         Text(value='while'), Space,
         Text(value='('), Attr('predicate'), Text(value=')'), OptionalSpace,
         Attr('statement'),
     ),
     'Null': (
+        CommentsAttr(),
         Text(value='null'),
     ),
     'String': (
+        CommentsAttr(),
         Attr(Literal()),
     ),
     'Continue': (
+        CommentsAttr(),
         Text(value='continue'), Optional('identifier', (
             RequiredSpace, Attr(attr='identifier'))), EndStatement,
     ),
     'Break': (
+        CommentsAttr(),
         Text(value='break'), Optional('identifier', (
             RequiredSpace, Attr(attr='identifier'),)), EndStatement,
     ),
     'Return': (
+        CommentsAttr(),
         Text(value='return'), Optional('expr', (
             Space, Attr(attr='expr'))), EndStatement,
     ),
     'With': (
+        CommentsAttr(),
         Text(value='with'), Space,
         # should _really_ have a token for logging a warning
         # https://developer.mozilla.org/en-US/docs/Web/JavaScript/
@@ -178,9 +213,11 @@ definitions = {
         Attr('statement'),
     ),
     'Label': (
+        CommentsAttr(),
         Attr('identifier'), Text(value=':'), Space, Attr('statement'),
     ),
     'Switch': (
+        CommentsAttr(),
         Text(value='switch'), Space,
         Text(value='('), Attr('expr'), Text(value=')'), Space,
         Attr('case_block'),
@@ -193,29 +230,35 @@ definitions = {
         CloseBlock,
     ),
     'Case': (
+        CommentsAttr(),
         Text(value='case'), Space, Attr('expr'), Text(value=':'),
         Indent, Newline,
         JoinAttr('elements', value=(Newline,)),
         Dedent,
     ),
     'Default': (
+        CommentsAttr(),
         Text(value='default'), Text(value=':'),
         Indent, Newline,
         JoinAttr('elements', value=(Newline,)),
         Dedent,
     ),
     'Throw': (
+        CommentsAttr(),
         Text(value='throw'), Space, Attr('expr'), EndStatement,
     ),
     'Debugger': (
+        CommentsAttr(),
         Text(value='debugger'), EndStatement,
     ),
     'Try': (
+        CommentsAttr(),
         Text(value='try'), Space, Attr('statements'),
         Optional('catch', (Newline, Attr('catch'),)),
         Optional('fin', (Newline, Attr('fin'),)),
     ),
     'Catch': (
+        CommentsAttr(),
         Text(value='catch'), Space,
         PushCatch,
         Text(value='('), Attr('identifier'), Text(value=')'), Space,
@@ -223,9 +266,11 @@ definitions = {
         PopCatch,
     ),
     'Finally': (
+        CommentsAttr(),
         Text(value='finally'), Space, Attr('elements'),
     ),
     'FuncDecl': (
+        CommentsAttr(),
         Text(value='function'), Optional('identifier', (RequiredSpace,)),
         Attr(Declare('identifier')), Text(value='('),
         PushScope, Optional('identifier', (ResolveFuncName,)),
@@ -239,6 +284,7 @@ definitions = {
         PopScope,
     ),
     'FuncExpr': (
+        CommentsAttr(),
         Text(value='function'), Optional('identifier', (RequiredSpace,)),
         Attr(Declare('identifier')), Text(value='('),
         PushScope, Optional('identifier', (ResolveFuncName,)),
@@ -252,29 +298,36 @@ definitions = {
         PopScope,
     ),
     'Conditional': (
+        CommentsAttr(),
         Attr('predicate'), Space, Text(value='?'), Space,
         Attr('consequent'), Space, Text(value=':'), Space,
         Attr('alternative'),
     ),
     'Regex': value,
     'NewExpr': (
+        CommentsAttr(),
         Text(value='new'), RequiredSpace, Attr('identifier'), Attr('args'),
     ),
     'DotAccessor': (
+        CommentsAttr(),
         Attr('node'), Text(value='.'), Attr('identifier'),
     ),
     'BracketAccessor': (
+        CommentsAttr(),
         Attr('node'), Text(value='['), Attr('expr'), Text(value=']'),
     ),
     'FunctionCall': (
+        CommentsAttr(),
         Attr('identifier'), Attr('args'),
     ),
     'Arguments': (
+        CommentsAttr(),
         Text(value='('),
         JoinAttr('items', value=(Text(value=','), Space)),
         Text(value=')'),
     ),
     'Object': (
+        CommentsAttr(),
         Text(value='{'),
         Optional('properties', (
             Indent, Newline,
@@ -284,15 +337,27 @@ definitions = {
         Text(value='}'),
     ),
     'Array': (
+        CommentsAttr(),
         Text(value='['),
         ElisionJoinAttr('items', value=(Space,)),
         Text(value=']'),
     ),
     'Elision': (
+        CommentsAttr(),
         ElisionToken(attr='value', value=','),
     ),
     'This': (
+        CommentsAttr(),
         Text(value='this'),
+    ),
+    'Comments': (
+        JoinAttr(Iter(), value=()),
+    ),
+    'LineComment': (
+        Attr(LineComment()), Newline,
+    ),
+    'BlockComment': (
+        Attr(BlockComment()), Newline,
     ),
 }
 


### PR DESCRIPTION
The provide changes should support the most typical use case in comments, except for perhaps right before a `else if` block, due to limitations with how the production rules are generated in `ply`. Yes this can be manually worked around, but not without significant additional effort.

Refer to the identity test case for the working examples (`PrintWithCommentsTestCase`).