### PR TITLE
fix #31: collections.abc imports

### DIFF
--- a/src/calmjs/parse/io.py
+++ b/src/calmjs/parse/io.py
@@ -4,7 +4,7 @@ Generic io functions for use with parsers.
 """
 
 from itertools import chain
-from collections import Iterable
+from collections.abc import Iterable
 from calmjs.parse.asttypes import Node
 from calmjs.parse import sourcemap
 from calmjs.parse.exceptions import ECMASyntaxError


### PR DESCRIPTION
Since Python 3.3 Collections Abstract Base Classes were moved
to collections.abc module. This raises warning on Python 3.7
and will stop working on Python 3.9