### PR TITLE
Correct JoinAttr handling of its values attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+?.?.? - ????-??-??
+------------------
+
+- Correct the JoinAttr ruletype such that the intended empty definition
+  value is passed to walk if it was defined as such to avoid an
+  unintended infinite recursion.
+
 1.2.5 - 2020-07-03
 ------------------
 

--- a/src/calmjs/parse/ruletypes.py
+++ b/src/calmjs/parse/ruletypes.py
@@ -312,8 +312,11 @@ class JoinAttr(Attr):
 
         for target_node in nodes:
             # note that self.value is to be defined in the definition
-            # format also.
-            for value_node in walk(dispatcher, node, self.value):
+            # format also - if it is None, the default lookup will be
+            # done again which would effectively repeat the previous
+            # walk as it will trigger a lookup!
+            definition = self.value if self.value else ()
+            for value_node in walk(dispatcher, node, definition=definition):
                 yield value_node
             for chunk in walk(dispatcher, target_node, token=self):
                 yield chunk

--- a/src/calmjs/parse/tests/test_unparsers_walker.py
+++ b/src/calmjs/parse/tests/test_unparsers_walker.py
@@ -210,6 +210,30 @@ class DispatcherWalkTestCase(unittest.TestCase):
         n3 = Block([Node([])] * 3)
         self.assertEqual(' nn', ''.join(c.text for c in walk(dispatcher, n3)))
 
+    def test_join_attr_issue_36(self):
+        # JoinAttr defined with parameter `value=None` resulted in
+        # infinite recursion due to the walker will assume that no rule
+        # is provided, triggering rule lookup which would repeat the
+        # work that was done.
+
+        class Block(Node):
+            pass
+
+        token_handler, layout_handlers, deferrable_handlers, declared_vars = (
+            setup_handlers(self))
+        dispatcher = Dispatcher(
+            definitions={
+                'Block': (JoinAttr(Iter(), value=None),),
+                'Node': (Text(value='',),),
+            },
+            token_handler=token_handler,
+            layout_handlers={},
+            deferrable_handlers={},
+        )
+
+        nodes = Block([Node([])] * 3)
+        self.assertEqual(3, len(list(walk(dispatcher, nodes))))
+
 
 class DispatcherTestcase(unittest.TestCase):
 

--- a/src/calmjs/parse/unparsers/walker.py
+++ b/src/calmjs/parse/unparsers/walker.py
@@ -187,7 +187,7 @@ class Dispatcher(object):
         """
 
         # The reason why the types were not used simply performance of
-        # isisntance is bad, that the types are uniquely named, and that
+        # isinstance is bad, that the types are uniquely named, and that
         # they are always subclassed through the factory.  While working
         # at the type level is the correct method, the performance
         # penalties that it attracts however make this naive approach


### PR DESCRIPTION
- The definitions provided to the walk function used for JoinAttr.value
  cannot be None, as that would trigger the automatic lookup of the
  rules defined for the node type, which would result in the same rules
  being executed again deeper down the stack, resulting in infinite
  recursion.
- The fix is to ensure an empty tuple is passed, so that the walker will
  correctly follow the intended empty (no) instruction and not trigger
  the issue.