### PR TITLE
Allow the option to optimize during setup.py build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-22.04, macos-latest]
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "pypy3.9"]
         include:
+          - os: ubuntu-22.04
+            python-version: "2.7"
           - os: windows-latest
             python-version: 3.9
           - os: windows-latest
@@ -41,10 +43,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }} via setup-python
+      if: matrix.python-version != '2.7'
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }} via apt-get
+      if: matrix.python-version == '2.7'
+      run: |
+        set -eux
+        sudo apt-get update
+        sudo apt-get install -y python2 python3-virtualenv
+        virtualenv -p python2 "${{ runner.temp }}/venv"
+        echo "${{ runner.temp }}/venv/bin" >> $GITHUB_PATH
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -64,7 +75,7 @@ jobs:
         coverage report -m
       continue-on-error: true
     - name: Coveralls
-      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version != '2.7' && matrix.python-version != 'pypy2' }}
+      if: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version != '2.7' && matrix.python-version != 'pypy2' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install coverage flake8
+        python -m pip install coverage flake8 ply
         python -m pip install -e .
     - name: Lint with flake8
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install coverage flake8 ply
+        # must install all dependencies so the tab modules can be generated
+        python -m pip install coverage flake8 ply setuptools
         python -m pip install -e .
     - name: Lint with flake8
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,11 @@ jobs:
       run: |
         python -OO -m unittest calmjs.parse.tests.make_suite
         coverage run --include=src/* -m unittest calmjs.parse.tests.make_suite
+    # Python 3.12 on Windows resulted in MemoryError here, so optional.
+    - name: Coverage report
+      run: |
         coverage report -m
+      continue-on-error: true
     - name: Coveralls
       if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version != '2.7' && matrix.python-version != 'pypy2' }}
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,27 +20,29 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", pypy2, pypy3]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "pypy3.9"]
         include:
           - os: windows-latest
             python-version: 3.9
           - os: windows-latest
             python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.11"
+          - os: windows-latest
+            python-version: "3.12"
         exclude:
           - os: macos-latest
             python-version: 3.5
           - os: macos-latest
             python-version: 3.6
           - os: macos-latest
-            python-version: pypy2
-          - os: macos-latest
-            python-version: pypy3
+            python-version: "pypy3.9"
 
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,9 +5,11 @@ Changelog
 ------------------
 
 - Modified existing ``setup.py`` hook from an install hook to a build
-  hook to ensure the generated module files are present.  Should they be
-  missing and ``ply`` is not already present this will result in a
-  non-zero exit.
+  hook to ensure the generated module files are present.  Should any of
+  those modules are missing and the required dependencies for are not
+  present (i.e. ``ply`` and ``setuptools``), the build will result in a
+  non-zero exit status and the documented error message should reflect
+  which of the required dependencies are missing.
 
 1.3.0 - 2021-10-08
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-1.3.1 - 20??-??-??
+1.3.1 - 2023-10-28
 ------------------
 
 - Modified existing ``setup.py`` hook from an install hook to a build

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+1.3.1 - 20??-??-??
+------------------
+
+- Modified existing ``setup.py`` hook from an install hook to a build
+  hook to ensure the generated module files are present.  Should they be
+  missing and ``ply`` is not already present this will result in a
+  non-zero exit.
+
 1.3.0 - 2021-10-08
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -107,18 +107,20 @@ git like so:
 
 .. code:: console
 
-    $ pip install ply  # this MUST be done first; see below for reason
+    $ pip install ply setuptools  # this MUST be done first; see below for reason
     $ pip install -e git+https://github.com/calmjs/calmjs.parse.git#egg=calmjs.parse
 
-Note that |ply| MUST be pre-installed for the ``setup.py build`` step to
-run, otherwise the build step required to create the pre-generated
-modules will result in the following failure condition, even when trying
-to package this library:
+Note that all dependencies MUST be pre-installed ``setup.py build`` step
+to run, otherwise the build step required to create the pre-generated
+modules will result in failure.
+
+If |ply| isn't installed:
 
 .. code:: console
 
-    $ python setup.py sdist --format=zip
-    running sdist
+    $ python -m pip install -e .
+    ...
+    running egg_info
     ...
     WARNING: cannot find distribution for 'ply'; using default value,
     assuming 'ply==3.11' for pre-generated modules
@@ -130,9 +132,25 @@ to package this library:
     before attempting to use the setup.py to build this package; please
     refer to the top level README for further details
 
+If ``setuptools`` isn't installed:
+
+.. code:: console
+
+    $ python -m pip install -e .
+    ...
+    running egg_info
+    ...
+    Traceback (most recent call last):
+      ...
+      File ".../calmjs.parse/src/calmjs/__init__.py", line 1, in <module>
+        __import__('pkg_resources').declare_namespace(__name__)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ModuleNotFoundError: No module named 'pkg_resources'
+
 Naturally, the git repository can be cloned directly and execute
 ``python setup.py develop`` while inside the root of the source
-directory; again, |ply| MUST already be available.
+directory; again, both |ply| AND ``setuptools`` MUST already have be
+available for import.
 
 As the git repository does NOT contain any pre-generated modules or
 code, the above message is likely to be seen by developers or distro
@@ -817,11 +835,19 @@ are regenerated every time that happens and this extra computational
 overhead should be corrected through the generation of that optimization
 module).
 
-This optimization module is included with the wheel release and the
+The optimization modules are included with the wheel release and the
 source release on PyPI, but it is not part of the source repository as
 generated code are never committed.  Should a binary release made by
 a third-party results in this warning upon import, their release should
 be corrected to include the optimization module.
+
+Moreover, there are safeguards in place that prevent this warning from
+being generated for releases made for releases from 1.3.1 onwards by
+a more heavy handed enforcement of this optimization step at build time,
+but persistent (or careless) actors may circumvent this during the build
+process, but official releases made through PyPI should include the
+required optimization for all supported |ply| versions (which are
+versions 3.6 to 3.11, inclusive).
 
 Slow performance
 ~~~~~~~~~~~~~~~~
@@ -836,17 +862,17 @@ this will may require both the token and layout functions not having
 arguments with name collisions, and the new function will take in all
 of those arguments in one go.
 
-ERROR message about `import ply` when trying to run setup.py
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ERROR message about import error when trying to install
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As noted in the full message, the |ply|_) package must be installed
-before attempting to build the package through ``setup.py`` in the
+As noted in the error message, the |ply|_ and ``setuptools`` package
+must be installed before attempting to install build the package in the
 situation where the pre-generated modules are missing.  This situation
 may be caused by building directly using the source provided by the
 source code repository, or where there is no matching pre-generated
-module matching with the installed version of |ply|.  Please ensure
-that |ply| is installed and available first before installing from
-source if this error message is sighted.
+module matching with the installed version of |ply|.  Please ensure that
+|ply| is installed and available first before installing from source if
+this error message is sighted.
 
 
 Contribute

--- a/README.rst
+++ b/README.rst
@@ -805,6 +805,24 @@ A workaround helper script is provided, it may be executed like so:
 Further details on this topic may be found in the `manual optimization`_
 section of this document.
 
+WARNING: There are unused tokens on import
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This indicates that the installation method or source for this package
+being imported isn't optimized.  A quick workaround is to follow the
+instructions at the `manual optimization`_ section of this document to
+ensure these messages are no longer generated (and if this warning
+happens every time the module is imported, it means the symbol tables
+are regenerated every time that happens and this extra computational
+overhead should be corrected through the generation of that optimization
+module).
+
+This optimization module is included with the wheel release and the
+source release on PyPI, but it is not part of the source repository as
+generated code are never committed.  Should a binary release made by
+a third-party results in this warning upon import, their release should
+be corrected to include the optimization module.
+
 Slow performance
 ~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -78,9 +78,8 @@ As this package uses |ply|, it requires the generation of optimization
 modules for its lexer.  The wheel distribution of |calmjs.parse| does
 not require this extra step as it contains these pre-generated modules
 for |ply| up to version 3.11 (the latest version available at the time
-of previous release), however the source tarball or if |ply| version
-that is installed lies outside of the supported versions, the following
-caveats will apply.
+of previous release), however the version of |ply| that is installed is
+beyond the supported version, the following caveats will apply.
 
 If a more recent release of |ply| becomes available and the environment
 upgrades to that version, those pre-generated modules may become
@@ -89,11 +88,18 @@ A corrective action can be achieved through a `manual optimization`_
 step if a newer version of |calmjs.parse| is not available, or |ply| may
 be downgraded back to version 3.11 if possible.
 
+Alternatively, install a more recent version of |calmjs.parse| wheel
+that has the most complete set of pre-generated modules built.
+
 Once the package is installed, the installation may be `tested`_ or be
 `used directly`_.
 
-Alternative installation methods (for developers, advanced users)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Manual installation and packaging requirements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+*This section is for developers and advanced users; contains important
+information for package maintainers for OS distributions (e.g. Linux)
+that will prevent less than ideal experiences for downstream users.*
 
 Development is still ongoing with |calmjs.parse|, for the latest
 features and bug fixes, the development version may be installed through
@@ -101,14 +107,43 @@ git like so:
 
 .. code:: console
 
-    $ pip install git+https://github.com/calmjs/calmjs.parse.git#egg=calmjs.parse
+    $ pip install ply  # this MUST be done first; see below for reason
+    $ pip install -e git+https://github.com/calmjs/calmjs.parse.git#egg=calmjs.parse
 
-Alternatively, the git repository can be cloned directly and execute
+Note that |ply| MUST be pre-installed for the ``setup.py build`` step to
+run, otherwise the build step required to create the pre-generated
+modules will result in the following failure condition, even when trying
+to package this library:
+
+.. code:: console
+
+    $ python setup.py sdist --format=zip
+    running sdist
+    ...
+    WARNING: cannot find distribution for 'ply'; using default value,
+    assuming 'ply==3.11' for pre-generated modules
+    ERROR: cannot find pre-generated modules for the assumed 'ply'
+    version from above and/or cannot `import ply` to build generated
+    modules, aborting build; please either ensure that the source
+    archive containing the pre-generate modules is being used, or that
+    the python package 'ply' is installed and available for import
+    before attempting to use the setup.py to build this package; please
+    refer to the top level README for further details
+
+Naturally, the git repository can be cloned directly and execute
 ``python setup.py develop`` while inside the root of the source
-directory.
+directory; again, |ply| MUST already be available.
 
-A manual optimization step may need to be performed for platforms and
-systems that do not have utf8 as their default encoding.
+As the git repository does NOT contain any pre-generated modules or
+code, the above message is likely to be seen by developers or distro
+maintainers who are on their first try at interacting with this
+software.  However, the zip archives released on PyPI starting from
+version 1.3.0 do contain these modules fully pre-generated, thus they
+may be used as part of a standard installation step, i.e. without
+requiring |ply| be available for import before usage of the ``setup.py``
+for any purpose.  While the same warning message about |ply| being
+missing may be shown, the pre-generated modules will allow the build
+step to proceed as normal.
 
 Manual optimization
 ~~~~~~~~~~~~~~~~~~~
@@ -714,6 +749,7 @@ Object assignments from a given script file:
 Further details and example usage can be consulted from the various
 docstrings found within the module.
 
+
 Limitations
 -----------
 
@@ -734,6 +770,7 @@ tokens and the node as implemented only provides a single slot for
 comments.  Likewise, any comments before the ``:`` token in a ternary
 statement will also be discarded as that is the second token consumed
 by the production rule that produces a ``Conditional`` node.
+
 
 Troubleshooting
 ---------------
@@ -780,6 +817,18 @@ the resolved generator functions for each asttype Node type, however
 this will may require both the token and layout functions not having
 arguments with name collisions, and the new function will take in all
 of those arguments in one go.
+
+ERROR message about `import ply` when trying to run setup.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As noted in the full message, the |ply|_) package must be installed
+before attempting to build the package through ``setup.py`` in the
+situation where the pre-generated modules are missing.  This situation
+may be caused by building directly using the source provided by the
+source code repository, or where there is no matching pre-generated
+module matching with the installed version of |ply|.  Please ensure
+that |ply| is installed and available first before installing from
+source if this error message is sighted.
 
 
 Contribute

--- a/README.rst
+++ b/README.rst
@@ -142,9 +142,6 @@ If ``setuptools`` isn't installed:
     ...
     Traceback (most recent call last):
       ...
-      File ".../calmjs.parse/src/calmjs/__init__.py", line 1, in <module>
-        __import__('pkg_resources').declare_namespace(__name__)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ModuleNotFoundError: No module named 'pkg_resources'
 
 Naturally, the git repository can be cloned directly and execute

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,24 +1,21 @@
+image: Visual Studio 2022
+
 environment:
   matrix:
     - PYTHON: "C:\\Python27"
-      nodejs_version: "4.6"
     - PYTHON: "C:\\Python33"
-      nodejs_version: "4.6"
     - PYTHON: "C:\\Python34"
-      nodejs_version: "6.9"
     - PYTHON: "C:\\Python35"
-      nodejs_version: "6.9"
     - PYTHON: "C:\\Python36"
-      nodejs_version: "8"
     - PYTHON: "C:\\Python37"
-      nodejs_version: "10"
     - PYTHON: "C:\\Python38"
-      nodejs_version: "10"
+    - PYTHON: "C:\\Python39-x64"
+    - PYTHON: "C:\\Python310-x64"
+    - PYTHON: "C:\\Python311-x64"
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - ps: Install-Product node $env:nodejs_version
-  - "%PYTHON%\\python.exe -m pip install coverage ply"
+  - "%PYTHON%\\python.exe -m pip install setuptools coverage ply"
   - "%PYTHON%\\python.exe setup.py install"
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - ps: Install-Product node $env:nodejs_version
-  - "%PYTHON%\\python.exe -m pip install coverage"
+  - "%PYTHON%\\python.exe -m pip install coverage ply"
   - "%PYTHON%\\python.exe setup.py install"
 
 test_script:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,17 @@ import atexit
 import sys
 from setuptools import setup, find_packages
 from setuptools.command.install import install
+from setuptools.command.build_py import build_py
 from subprocess import call
+
+
+class BuildHook(build_py):
+    """Forcing the optimizer to run before the build step"""
+    def __init__(self, *a, **kw):
+        call([sys.executable, '-m', 'calmjs.parse.parsers.optimize'], env={
+            'PYTHONPATH': 'src'
+        })
+        build_py.__init__(self, *a, **kw)
 
 
 class InstallHook(install):
@@ -60,6 +70,7 @@ setup(
     zip_safe=False,
     cmdclass={
         'install': InstallHook,
+        'build_py': BuildHook,
     },
     install_requires=[
         'setuptools',

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
+Programming Language :: Python :: 3.11
+Programming Language :: Python :: 3.12
 """.strip().splitlines()
 
 long_description = (

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
-import atexit
 import sys
 from setuptools import setup, find_packages
-from setuptools.command.install import install
 from setuptools.command.build_py import build_py
 from subprocess import call
 
@@ -9,18 +7,14 @@ from subprocess import call
 class BuildHook(build_py):
     """Forcing the optimizer to run before the build step"""
     def __init__(self, *a, **kw):
-        call([sys.executable, '-m', 'calmjs.parse.parsers.optimize'], env={
+        code = call([
+            sys.executable, '-m', 'calmjs.parse.parsers.optimize', '--build'
+        ], env={
             'PYTHONPATH': 'src'
         })
+        if code:
+            sys.exit(1)
         build_py.__init__(self, *a, **kw)
-
-
-class InstallHook(install):
-    """For hooking the optimizer when setup exits"""
-    def __init__(self, *a, **kw):
-        install.__init__(self, *a, **kw)
-        atexit.register(
-            call, [sys.executable, '-m', 'calmjs.parse.parsers.optimize'])
 
 
 # Attributes
@@ -69,7 +63,6 @@ setup(
     include_package_data=True,
     zip_safe=False,
     cmdclass={
-        'install': InstallHook,
         'build_py': BuildHook,
     },
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from setuptools import setup, find_packages
 from setuptools.command.build_py import build_py
@@ -7,11 +8,12 @@ from subprocess import call
 class BuildHook(build_py):
     """Forcing the optimizer to run before the build step"""
     def __init__(self, *a, **kw):
+        # must use clone of this, otherwise Python on Windows gets sad.
+        env = os.environ.copy()
+        env['PYTHONPATH'] = 'src'
         code = call([
             sys.executable, '-m', 'calmjs.parse.parsers.optimize', '--build'
-        ], env={
-            'PYTHONPATH': 'src'
-        })
+        ], env=env)
         if code:
             sys.exit(1)
         build_py.__init__(self, *a, **kw)

--- a/src/calmjs/parse/__init__.py
+++ b/src/calmjs/parse/__init__.py
@@ -3,7 +3,14 @@
 Quick access helper functions
 """
 
-from calmjs.parse.factory import ParserUnparserFactory
+try:
+    from calmjs.parse.factory import ParserUnparserFactory
+except ImportError as e:  # pragma: no cover
+    exc = e
 
+    def import_error(*a, **kw):
+        raise exc
 
-es5 = ParserUnparserFactory('es5', 'pretty_print', 'minify_print')
+    es5 = import_error
+else:
+    es5 = ParserUnparserFactory('es5', 'pretty_print', 'minify_print')

--- a/src/calmjs/parse/parsers/es5.py
+++ b/src/calmjs/parse/parsers/es5.py
@@ -42,8 +42,10 @@ from calmjs.parse.io import read as io_read
 
 asttypes = AstTypesFactory(pretty_print, ReprWalker())
 
-# The default values for the `Parser` constructor, passed on to ply; they must
-# be strings
+# These default values for the `Parser` constructor, passed on to ply;
+# they must be strings; these values are for reference only as
+# modifications to this value will not change what's been set up as
+# the Parser's default.
 lextab, yacctab = generate_tab_names(__name__)
 
 

--- a/src/calmjs/parse/parsers/optimize.py
+++ b/src/calmjs/parse/parsers/optimize.py
@@ -115,12 +115,15 @@ def optimize_build(module_name, assume_ply_version=True):
     if assume_ply_version:
         kws['_version'] = _assume_ply_version()
 
-    paths, missing = validate_imports(*generate_tab_names(module_name, **kws))
+    lextab, yacctab = generate_tab_names(module_name, **kws)
+    paths, missing = validate_imports(lextab, yacctab)
     if missing:
         # only import, purge and regenerate if any are missing.
         unlink_modules(verify_paths(paths))
         module = import_module(module_name)
-        module.Parser()
+        # use whatever assumed version or otherwise as set up by
+        # the local generation function.
+        module.Parser(lextab=lextab, yacctab=yacctab)
 
 
 def reoptimize_all(monkey_patch=False, first_build=False):

--- a/src/calmjs/parse/parsers/optimize.py
+++ b/src/calmjs/parse/parsers/optimize.py
@@ -90,7 +90,16 @@ def _assume_ply_version():
         if _ASSUME_ENVVAR in os.environ:
             source = "using environment variable %r" % _ASSUME_ENVVAR
         else:
-            source = "using default value"
+            # allow bypassing of setuptools as ply provides this
+            # attribute
+            try:
+                import ply
+                version = ply.__version__
+                source = "using value provided by ply"
+            except ImportError:  # pragma: no cover
+                ply = None
+                source = "using default value"
+
         sys.stderr.write(
             u"WARNING: cannot find distribution for 'ply'; "
             "%s, assuming 'ply==%s' for pre-generated modules\n" % (
@@ -107,6 +116,10 @@ def optimize_build(module_name, assume_ply_version=True):
         ply be NOT installed; this will either assume ply to be whatever
         value assigned to _ASSUME_PLY_VERSION (i.e. 3.11), or read from
         the environment variable `CALMJS_PARSE_ASSUME_PLY_VERSION`.
+
+        The goal is to allow the build to proceed if the pre-generated
+        files are already present, before the dependency resolution at
+        the installation time actually kicks in to install ply.
 
         Default: True
     """

--- a/src/calmjs/parse/tests/test_parsers_optimize.py
+++ b/src/calmjs/parse/tests/test_parsers_optimize.py
@@ -121,7 +121,7 @@ class OptimizeTestCase(unittest.TestCase):
     def test_optimize_build(self):
         called = []
 
-        def sentinel():
+        def sentinel(*a, **kw):
             called.append(True)
 
         fake_es5 = ModuleType('fake_namespace.fake_es5')
@@ -227,7 +227,7 @@ class OptimizeTestCase(unittest.TestCase):
         optimize.ply_dist = None
         called = []
 
-        def sentinel():
+        def sentinel(*a, **kw):
             called.append(True)
 
         fake_es5 = ModuleType('fake_namespace.fake_es5')

--- a/src/calmjs/parse/utils.py
+++ b/src/calmjs/parse/utils.py
@@ -14,11 +14,13 @@ try:
     from pkg_resources import Requirement
     ply_dist = working_set.find(Requirement.parse('ply'))
     # note that for **extremely** ancient versions of setuptools, e.g.
-    # setuptools<0.6c11, will require the following workaround...
-    # if ply_dist is None:
-    #     from pkg_resources import Distribution
-    #     import ply
-    #     ply_dist = Distribution(project_name='ply', version=ply.__version__)
+    # setuptools<0.6c11, or some very non-standard environment that does
+    # not include the required metadata (e.g. pyinstaller without the
+    # required metadata), will require the following workaround...
+    if ply_dist is None:  # pragma: no cover
+        from pkg_resources import Distribution
+        import ply
+        ply_dist = Distribution(project_name='ply', version=ply.__version__)
 except ImportError:  # pragma: no cover
     ply_dist = None
 

--- a/src/calmjs/parse/utils.py
+++ b/src/calmjs/parse/utils.py
@@ -13,6 +13,12 @@ try:
     from pkg_resources import working_set
     from pkg_resources import Requirement
     ply_dist = working_set.find(Requirement.parse('ply'))
+    # note that for **extremely** ancient versions of setuptools, e.g.
+    # setuptools<0.6c11, will require the following workaround...
+    # if ply_dist is None:
+    #     from pkg_resources import Distribution
+    #     import ply
+    #     ply_dist = Distribution(project_name='ply', version=ply.__version__)
 except ImportError:  # pragma: no cover
     ply_dist = None
 
@@ -34,7 +40,7 @@ def repr_compat(s):
         return repr(s)
 
 
-def generate_tab_names(name):
+def generate_tab_names(name, _version='unknown'):
     """
     Return the names to lextab and yacctab modules for the given module
     name.  Typical usage should be like so::
@@ -44,8 +50,8 @@ def generate_tab_names(name):
 
     package_name, module_name = name.rsplit('.', 1)
 
-    version = ply_dist.version.replace(
-        '.', '_') if ply_dist is not None else 'unknown'
+    version = (ply_dist.version if ply_dist is not None else _version).replace(
+        '.', '_')
     data = (package_name, module_name, py_major, version)
     lextab = '%s.lextab_%s_py%d_ply%s' % data
     yacctab = '%s.yacctab_%s_py%d_ply%s' % data


### PR DESCRIPTION
This mostly is here to help with distro package maintainers in ensuring that they have the *tab modules available for their end users as they may opt to use the tarball generated by the source repository (i.e. Github) instead of the one from PyPI. Refer to calmjs/calmjs#61 for the discussion that lead to the discovery of this packaging workflow issue.

Note that this would likely require the source package distributed with PyPI include all versions of these generated source files, likely for Python 2 if the desire for compatibility with very legacy build systems (e.g. buildout<2 with ancient setuptools) is desired coupled with a build step that hard fails, e.g.

```
$ buildout 
Installing python.
Getting distribution for 'ply'.
warning: no previously-included files matching '*.pyc' found anywhere in distribution
zip_safe flag not set; analyzing archive contents...
ply.ygen: module references __file__
ply.yacc: module references __file__
ply.yacc: module MAY be using inspect.getsourcefile
ply.yacc: module MAY be using inspect.stack
ply.lex: module references __file__
ply.lex: module MAY be using inspect.getsourcefile
Got ply 3.11.
Getting distribution for 'calmjs.parse'.
ERROR: cannot import ply, aborting build; please ensure that the python package 'ply' is installed before attempting to build this package; please refer to the top level README for further details
error: Setup script exited with 1
An error occurred when trying to install calmjs.parse 1.3.0rc0. Look above this message for any errors that were output by easy_install.
While:
  Installing python.
  Getting distribution for 'calmjs.parse'.
Error: Couldn't install: calmjs.parse 1.3.0rc0
```

Clearly this would not be ideal.