### PR TITLE
Py313

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,43 +19,30 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest]
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "pypy3.9"]
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.10"]
         include:
-          - os: ubuntu-22.04
-            python-version: "2.7"
-          - os: windows-latest
-            python-version: 3.9
-          - os: windows-latest
-            python-version: "3.10"
           - os: windows-latest
             python-version: "3.11"
           - os: windows-latest
             python-version: "3.12"
+          - os: windows-latest
+            python-version: "3.13"
         exclude:
           - os: macos-latest
-            python-version: 3.5
+            python-version: 3.9
           - os: macos-latest
-            python-version: 3.6
+            python-version: 3.10
           - os: macos-latest
-            python-version: "pypy3.9"
+            python-version: "pypy3.10"
 
 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }} via setup-python
-      if: matrix.python-version != '2.7'
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Set up Python ${{ matrix.python-version }} via apt-get
-      if: matrix.python-version == '2.7'
-      run: |
-        set -eux
-        sudo apt-get update
-        sudo apt-get install -y python2 python3-virtualenv
-        virtualenv -p python2 "${{ runner.temp }}/venv"
-        echo "${{ runner.temp }}/venv/bin" >> $GITHUB_PATH
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -75,7 +62,7 @@ jobs:
         coverage report -m
       continue-on-error: true
     - name: Coveralls
-      if: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version != '2.7' && matrix.python-version != 'pypy2' }}
+      if: ${{ matrix.os == 'ubuntu-22.04' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+1.3.2 - 2024-10-17
+------------------
+
+- Ensure building from source tree under Python 3.13 works.
+- Dropped support for building under Python 2 in source tree. [
+  `#44 <https://github.com/calmjs/calmjs.parse/issues/44>`_
+  ]
+
 1.3.1 - 2023-10-28
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,9 @@ Changelog
   those modules are missing and the required dependencies for are not
   present (i.e. ``ply`` and ``setuptools``), the build will result in a
   non-zero exit status and the documented error message should reflect
-  which of the required dependencies are missing.
+  which of the required dependencies are missing.  [
+  `#41 <https://github.com/calmjs/calmjs.parse/issues/41>`_
+  ]
 
 1.3.0 - 2021-10-08
 ------------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,16 +2,8 @@ image: Visual Studio 2022
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python33"
-    - PYTHON: "C:\\Python34"
-    - PYTHON: "C:\\Python35"
-    - PYTHON: "C:\\Python36"
-    - PYTHON: "C:\\Python37"
-    - PYTHON: "C:\\Python38"
-    - PYTHON: "C:\\Python39-x64"
-    - PYTHON: "C:\\Python310-x64"
-    - PYTHON: "C:\\Python311-x64"
+    - PYTHON: "C:\\Python312-x64"
+    - PYTHON: "C:\\Python313-x64"
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
@@ -21,7 +13,9 @@ install:
 test_script:
   - python setup.py develop
   - coverage run --include=src\* -m unittest calmjs.parse.tests.make_suite
-  - coverage report -m
+  # This is now broken on appveyor for whatever reason.  Why does Python
+  # and their tools just break?
+  # - coverage report -m
 
 artifacts:
   - path: dist\*

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from setuptools import setup, find_packages
+from setuptools import setup
 from setuptools.command.build_py import build_py
 from subprocess import call
 
@@ -29,7 +29,6 @@ Intended Audience :: Developers
 License :: OSI Approved :: MIT License
 Operating System :: OS Independent
 Programming Language :: JavaScript
-Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
@@ -40,6 +39,7 @@ Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3.11
 Programming Language :: Python :: 3.12
+Programming Language :: Python :: 3.13
 """.strip().splitlines()
 
 long_description = (
@@ -61,9 +61,14 @@ setup(
     author_email='tommy.yu@auckland.ac.nz',
     url='https://github.com/calmjs/calmjs.parse',
     license='mit',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['calmjs'],
+    # To build this under Python 2, create src/calmjs/__init__.py with
+    #
+    #     __import__('pkg_resources').declare_namespace(__name__)
+    #
+    # and uncomment the following:
+    # packages=find_packages('src'),
+    # package_dir={'': 'src'},
+    # namespace_packages=['calmjs'],
     include_package_data=True,
     zip_safe=False,
     cmdclass={
@@ -73,6 +78,7 @@ setup(
         'setuptools',
         'ply>=3.6',
     ],
+    python_requires='>=3.3',
     entry_points={
     },
     test_suite="calmjs.parse.tests.make_suite",

--- a/src/calmjs/__init__.py
+++ b/src/calmjs/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/src/calmjs/parse/tests/__init__.py
+++ b/src/calmjs/parse/tests/__init__.py
@@ -6,6 +6,7 @@ import unittest
 import doctest
 from textwrap import dedent
 from io import StringIO
+from os.path import basename
 from os.path import dirname
 from pkg_resources import get_distribution
 
@@ -31,14 +32,27 @@ examples = {
 }
 
 
+class StringIOWrapper(StringIO):
+    """
+    Needed to rstrip the output to make all doctest output behave in a
+    consistent way across all platforms because for whatever reason the
+    doctest has different behaviors between Windows and others...
+    """
+
+    def read(self):
+        return StringIO.read(self).rstrip()
+
+
 def make_suite():  # pragma: no cover
     from calmjs.parse.lexers import es5 as es5lexer
     from calmjs.parse import walkers
     from calmjs.parse import sourcemap
 
     def open(p, flag='r'):
-        result = StringIO(examples[p] if flag == 'r' else '')
-        result.name = p
+        result = StringIOWrapper(examples[p] if flag == 'r' else '')
+        # Need basename here because Python 3.13 under Windows broke
+        # _something_ and made the reporting inconsistent...
+        result.name = basename(p)
         return result
 
     parser = doctest.DocTestParser()


### PR DESCRIPTION
Dropping support for building under Python 2.7.

Given that this package is unlikely to receive further development, lack of release for Python 2 is unlikely to be any hindrance to anyone.  If I am going to do a future release I am probably going to wrap some library built with Rust and bring it over via PyO3 and call it a day.